### PR TITLE
Rewrite and naming of Coordinate Equal and Math

### DIFF
--- a/Example/GeoFeatures2.xcodeproj/project.pbxproj
+++ b/Example/GeoFeatures2.xcodeproj/project.pbxproj
@@ -14,13 +14,13 @@
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		BF5C19E555F0BB8ED799E286 /* Pods_GeoFeatures2_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B88AC2CCDA7AA09BD031B8E /* Pods_GeoFeatures2_Example.framework */; };
 		DABEEBC540582F4C4AB425AA /* Pods_GeoFeatures2_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28E76E80829A6C416EFFD976 /* Pods_GeoFeatures2_Tests.framework */; };
-		EAB4C1C41C6F7CB600F288D1 /* Coordinate2DTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB4C1B61C6F7C3F00F288D1 /* Coordinate2DTests.swift */; };
 		EAB4C1C51C6F7CBA00F288D1 /* Coordinate3DTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB4C1B71C6F7C3F00F288D1 /* Coordinate3DTests.swift */; };
 		EAB4C1C61C6F7CBD00F288D1 /* FixedPrecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB4C1B81C6F7C3F00F288D1 /* FixedPrecisionTests.swift */; };
 		EAB4C1C71C6F7CC100F288D1 /* FloatingPrecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB4C1B91C6F7C3F00F288D1 /* FloatingPrecisionTests.swift */; };
 		EAB4C1C81C6F7CC500F288D1 /* LineStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB4C1BA1C6F7C3F00F288D1 /* LineStringTests.swift */; };
 		EAB4C1C91C6F7CC900F288D1 /* PointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB4C1BB1C6F7C3F00F288D1 /* PointTests.swift */; };
 		EAB4C1CA1C6F7CCE00F288D1 /* WKTReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB4C1BC1C6F7C3F00F288D1 /* WKTReaderTests.swift */; };
+		EAF80EA11C72B1FA0042D01A /* Coordinate2DTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA799B731C72AD7800397C2A /* Coordinate2DTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,7 +52,7 @@
 		CD829F37916D32011B39AD57 /* GeoFeatures2.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = GeoFeatures2.podspec; path = ../GeoFeatures2.podspec; sourceTree = "<group>"; };
 		EA799B4D1C723E0700397C2A /* GeoFeatures-Diagrams.graffle */ = {isa = PBXFileReference; lastKnownFileType = file; name = "GeoFeatures-Diagrams.graffle"; path = "../Docs/GeoFeatures-Diagrams.graffle"; sourceTree = "<group>"; };
 		EA799B4E1C723E0700397C2A /* GeoFeatures-Inheritance-Diagram.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "GeoFeatures-Inheritance-Diagram.png"; path = "../Docs/GeoFeatures-Inheritance-Diagram.png"; sourceTree = "<group>"; };
-		EAB4C1B61C6F7C3F00F288D1 /* Coordinate2DTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Coordinate2DTests.swift; sourceTree = "<group>"; };
+		EA799B731C72AD7800397C2A /* Coordinate2DTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Coordinate2DTests.swift; sourceTree = "<group>"; };
 		EAB4C1B71C6F7C3F00F288D1 /* Coordinate3DTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Coordinate3DTests.swift; sourceTree = "<group>"; };
 		EAB4C1B81C6F7C3F00F288D1 /* FixedPrecisionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FixedPrecisionTests.swift; sourceTree = "<group>"; };
 		EAB4C1B91C6F7C3F00F288D1 /* FloatingPrecisionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingPrecisionTests.swift; sourceTree = "<group>"; };
@@ -143,7 +143,7 @@
 			children = (
 				EAB4C1B81C6F7C3F00F288D1 /* FixedPrecisionTests.swift */,
 				EAB4C1B91C6F7C3F00F288D1 /* FloatingPrecisionTests.swift */,
-				EAB4C1B61C6F7C3F00F288D1 /* Coordinate2DTests.swift */,
+				EA799B731C72AD7800397C2A /* Coordinate2DTests.swift */,
 				EAB4C1B71C6F7C3F00F288D1 /* Coordinate3DTests.swift */,
 				EAB4C1BA1C6F7C3F00F288D1 /* LineStringTests.swift */,
 				EAB4C1BB1C6F7C3F00F288D1 /* PointTests.swift */,
@@ -412,8 +412,8 @@
 				EAB4C1C61C6F7CBD00F288D1 /* FixedPrecisionTests.swift in Sources */,
 				EAB4C1C51C6F7CBA00F288D1 /* Coordinate3DTests.swift in Sources */,
 				EAB4C1C81C6F7CC500F288D1 /* LineStringTests.swift in Sources */,
+				EAF80EA11C72B1FA0042D01A /* Coordinate2DTests.swift in Sources */,
 				EAB4C1C71C6F7CC100F288D1 /* FloatingPrecisionTests.swift in Sources */,
-				EAB4C1C41C6F7CB600F288D1 /* Coordinate2DTests.swift in Sources */,
 				EAB4C1CA1C6F7CCE00F288D1 /* WKTReaderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -21,13 +21,11 @@
 		40848EA96C0CE8AA8E5056BBD64CFDF7 /* Polygon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44B890FB2C368F57DC6ED2BBC542B64F /* Polygon.swift */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		412830F01D8EB25D932F82B7C66604FB /* FloatingPrecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B2B95D05B73122C7FF80AE8CD0D1C5 /* FloatingPrecision.swift */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		546968BB8D0EF10350A56BD4C805FDB8 /* GeoJSONReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC33652701CC5800E68D16C3B43445B6 /* GeoJSONReader.swift */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		58465D96DFFDCCF8139966163753C408 /* Coordinate2D.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF7EAA68BD3F94CBE12AB9EB5FE34DF /* Coordinate2D.swift */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		721C7C892016D0F4FF1367B79031E10B /* LineString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606B789A38E4186E113B5B1532AA88E9 /* LineString.swift */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		7A29A76573DBADA43139B58F1B203DE8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E4E89230EF59BC255123B67864ACF77 /* Foundation.framework */; };
 		7F493F9D2DC4F6CBB4E811C74B8FE093 /* GeoFeatures2-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = AD9C46C0BB55129A127B2FECEEED884E /* GeoFeatures2-dummy.m */; };
 		8872BEAA5A6AD71C6F29BC414BD128BF /* ArealType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0212675BF48F5AA3EFA8CC59FC1A633E /* ArealType.swift */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		912287F8BC4731FA786A825227CAC267 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E4E89230EF59BC255123B67864ACF77 /* Foundation.framework */; };
-		9C3BA8D3AB5B52F8A6CD4B9E2D778905 /* Coordinate3D.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE149D2A2C2D7726EC2AF34EC984AD3A /* Coordinate3D.swift */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		9E7636500B7738F58CEDB5EB471457C4 /* WKTReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74307892050DBC5359CDEB0976A7CF8B /* WKTReader.swift */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		B1B0E2A2A929DCF7F6F867F8263B524C /* LinearType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F15C849E8E06A85B083B69A8DB9F0D4 /* LinearType.swift */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		BC53E9CA98FF5E5F738F42B33CBE739A /* MultiPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384C7F077003CCAF17D0CA1CFA5107F8 /* MultiPoint.swift */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
@@ -49,6 +47,8 @@
 		EA799B6E1C72663C00397C2A /* Point+GeometryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA799B631C72663C00397C2A /* Point+GeometryType.swift */; };
 		EA799B6F1C72663C00397C2A /* Polygon+ArealType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA799B641C72663C00397C2A /* Polygon+ArealType.swift */; };
 		EA799B701C72663C00397C2A /* Polygon+GeometryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA799B651C72663C00397C2A /* Polygon+GeometryType.swift */; };
+		EAF80E9F1C72AED40042D01A /* Coordinate2D.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF80E9D1C72AED40042D01A /* Coordinate2D.swift */; };
+		EAF80EA01C72AED40042D01A /* Coordinate3D.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF80E9E1C72AED40042D01A /* Coordinate3D.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -103,7 +103,6 @@
 		92D7F924CF41117028AE8F910CCEFB65 /* GeoFeatures2-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "GeoFeatures2-umbrella.h"; sourceTree = "<group>"; };
 		939424AF760C3B02AD2C5EF594355B5F /* GeoFeatures2.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = GeoFeatures2.modulemap; sourceTree = "<group>"; };
 		9A278F0E73A33E2C20658F4CBBB08F70 /* Pods-GeoFeatures2_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-GeoFeatures2_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		AAF7EAA68BD3F94CBE12AB9EB5FE34DF /* Coordinate2D.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Coordinate2D.swift; sourceTree = "<group>"; };
 		AC33652701CC5800E68D16C3B43445B6 /* GeoJSONReader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GeoJSONReader.swift; sourceTree = "<group>"; };
 		AC72F3F09945F761F5FED8595306D904 /* GeometryType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GeometryType.swift; sourceTree = "<group>"; };
 		AD9C46C0BB55129A127B2FECEEED884E /* GeoFeatures2-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "GeoFeatures2-dummy.m"; sourceTree = "<group>"; };
@@ -111,7 +110,6 @@
 		B52E8538CB4903D76F1054C592341F25 /* Pods-GeoFeatures2_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-GeoFeatures2_Example-dummy.m"; sourceTree = "<group>"; };
 		BA1E006BE1CDEDDCC2EED2247C8164DE /* FixedPrecision.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FixedPrecision.swift; sourceTree = "<group>"; };
 		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		BE149D2A2C2D7726EC2AF34EC984AD3A /* Coordinate3D.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Coordinate3D.swift; sourceTree = "<group>"; };
 		C739B1A4D124E3A4152072EF97A59A19 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C80A78AD3A39859F0FB5F9D2D8E209B1 /* Pods-GeoFeatures2_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-GeoFeatures2_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
 		CA47280D4D9B43CE4938BAE1E51A4252 /* Pods-GeoFeatures2_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-GeoFeatures2_Tests.release.xcconfig"; sourceTree = "<group>"; };
@@ -132,6 +130,8 @@
 		EA799B631C72663C00397C2A /* Point+GeometryType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Point+GeometryType.swift"; sourceTree = "<group>"; };
 		EA799B641C72663C00397C2A /* Polygon+ArealType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Polygon+ArealType.swift"; sourceTree = "<group>"; };
 		EA799B651C72663C00397C2A /* Polygon+GeometryType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Polygon+GeometryType.swift"; sourceTree = "<group>"; };
+		EAF80E9D1C72AED40042D01A /* Coordinate2D.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Coordinate2D.swift; sourceTree = "<group>"; };
+		EAF80E9E1C72AED40042D01A /* Coordinate3D.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Coordinate3D.swift; sourceTree = "<group>"; };
 		EE35618709650B77CB262E806E0F26B7 /* MultiPolygon.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MultiPolygon.swift; sourceTree = "<group>"; };
 		F12800ACBBA09FA0D85736915F680E46 /* Pods-GeoFeatures2_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-GeoFeatures2_Tests-frameworks.sh"; sourceTree = "<group>"; };
 		FFD35A803619C151D8C535A4853A6989 /* Pods-GeoFeatures2_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-GeoFeatures2_Example.modulemap"; sourceTree = "<group>"; };
@@ -269,8 +269,8 @@
 				BA1E006BE1CDEDDCC2EED2247C8164DE /* FixedPrecision.swift */,
 				52B2B95D05B73122C7FF80AE8CD0D1C5 /* FloatingPrecision.swift */,
 				6F8BC6AA3D95FFED5494E36CB9E3764D /* CoordinateReferenceSystem.swift */,
-				AAF7EAA68BD3F94CBE12AB9EB5FE34DF /* Coordinate2D.swift */,
-				BE149D2A2C2D7726EC2AF34EC984AD3A /* Coordinate3D.swift */,
+				EAF80E9D1C72AED40042D01A /* Coordinate2D.swift */,
+				EAF80E9E1C72AED40042D01A /* Coordinate3D.swift */,
 				AC72F3F09945F761F5FED8595306D904 /* GeometryType.swift */,
 				7F15C849E8E06A85B083B69A8DB9F0D4 /* LinearType.swift */,
 				0212675BF48F5AA3EFA8CC59FC1A633E /* ArealType.swift */,
@@ -446,9 +446,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EAF80EA01C72AED40042D01A /* Coordinate3D.swift in Sources */,
 				8872BEAA5A6AD71C6F29BC414BD128BF /* ArealType.swift in Sources */,
-				58465D96DFFDCCF8139966163753C408 /* Coordinate2D.swift in Sources */,
-				9C3BA8D3AB5B52F8A6CD4B9E2D778905 /* Coordinate3D.swift in Sources */,
 				EA799B6D1C72663C00397C2A /* MultiPolygon+GeometryType.swift in Sources */,
 				EA799B701C72663C00397C2A /* Polygon+GeometryType.swift in Sources */,
 				C4FF04B7A3DE18F81C05851F59BF9BE9 /* CoordinateReferenceSystem.swift in Sources */,
@@ -460,6 +459,7 @@
 				EA799B6C1C72663C00397C2A /* MultiPoint+GeometryType.swift in Sources */,
 				546968BB8D0EF10350A56BD4C805FDB8 /* GeoJSONReader.swift in Sources */,
 				EA799B691C72663C00397C2A /* LineString+GeometryType.swift in Sources */,
+				EAF80E9F1C72AED40042D01A /* Coordinate2D.swift in Sources */,
 				EA799B661C72663C00397C2A /* GeometryCollection+GeometryType.swift in Sources */,
 				318DF16AB2B4C17925197B8B0CE66A02 /* GeometryCollection.swift in Sources */,
 				1FE7B1B19C159B671093E5ED6921892F /* GeometryCollectonType.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/GeoFeatures2.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/GeoFeatures2.xcscheme
@@ -13,11 +13,11 @@
             buildForProfiling = "YES"
             buildForArchiving = "YES">
             <BuildableReference
-               BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '8F2D90A9039E7E41C1FE2AAF'
-               BlueprintName = 'GeoFeatures2'
-               ReferencedContainer = 'container:Pods.xcodeproj'
-               BuildableName = 'GeoFeatures2.framework'>
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FD9E5E942C433BC2CF8E9DAFC92A2AB5"
+               BlueprintName = "GeoFeatures2"
+               ReferencedContainer = "container:Pods.xcodeproj"
+               BuildableName = "GeoFeatures2.framework">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/Example/Tests/Coordinate2DTests.swift
+++ b/Example/Tests/Coordinate2DTests.swift
@@ -1,5 +1,5 @@
 /*
- *   Coordinate2DTests.swift
+ *   Coordinate3DTests.swift
  *
  *   Copyright 2016 Tony Stone
  *
@@ -21,28 +21,31 @@ import XCTest
 @testable import GeoFeatures2
 
 class Coordinate2DTests: XCTestCase {
-
+    
     // MARK: Equal
     
-    func testEqual_Zero()         { XCTAssertTrue((0.0,0.0) == (0.0,0.0)) }
+    func testEqual_Zero()         { XCTAssertTrue(coordinateEquals((0.0,0.0), (0.0,0.0))) }
     
-    func testEqual_One()          { XCTAssertTrue((1.0,1.0) == (1.0,1.0))  }
+    func testEqual_One()          { XCTAssertTrue(coordinateEquals((1.0,1.0), (1.0,1.0)))  }
     
-    func testEqual_Negative()     { XCTAssertTrue((-1.0,-1.0) == (-1.0,-1.0))  }
+    func testEqual_Negative()     { XCTAssertTrue(coordinateEquals((-1.0,-1.0), (-1.0,-1.0))) }
     
-    func testEqual_Small()        { XCTAssertTrue((0.0000000000000000001,0.0000000000000000001) == (0.0000000000000000001,0.0000000000000000001))  }
+    func testEqual_Small()        { XCTAssertTrue(coordinateEquals((0.0000000000000000001,0.0000000000000000001), (0.0000000000000000001,0.0000000000000000001))) }
     
-    func testEqual_Large()        { XCTAssertTrue((1000000000000000000.0,1000000000000000000.0) == (1000000000000000000.0,1000000000000000000.0))  }
+    func testEqual_Large()        { XCTAssertTrue(coordinateEquals((1000000000000000000.0,1000000000000000000.0), (1000000000000000000.0,1000000000000000000.0)))  }
     
     // MARK: Not Equal
-
-    func testNotEqual_Zero()         { XCTAssertFalse((0.0,0.0) == (1.0,0.0)) }
     
-    func testNotEqual_One()          { XCTAssertFalse((1.0,1.0) == (0.0,1.0))  }
+    func testNotEqual_Zero()         { XCTAssertFalse(coordinateEquals((0.0,0.0),(1.0,0.0))) }
     
-    func testNotEqual_Negative()     { XCTAssertFalse((-1.0,-1.0) == (-2.0,-1.0))  }
+    func testNotEqual_One()          { XCTAssertFalse(coordinateEquals((1.0,1.0),(0.0,1.0)))  }
     
-    func testNotEqual_Small()        { XCTAssertFalse((0.0000000000000000001,0.0000000000000000001) == (0.00000000000000000011,0.0000000000000000001))  }
+    func testNotEqual_Negative()     { XCTAssertFalse(coordinateEquals((-1.0,-1.0),(-2.0,-1.0)))  }
     
-    func testNotEqual_Large()        { XCTAssertFalse((1000000000000000000.0,1000000000000000000.0) == (1200000000000000000.0,1000000000000000000.0))  }
+    func testNotEqual_Small()        { XCTAssertFalse(coordinateEquals((0.0000000000000000001,0.0000000000000000001), (0.00000000000000000011,0.0000000000000000001)))  }
+    
+    func testNotEqual_Large()        { XCTAssertFalse(coordinateEquals((1000000000000000000.0,1000000000000000000.0), (1200000000000000000.0,1000000000000000000.0)))  }
+    
 }
+
+

--- a/Example/Tests/Coordinate3DTests.swift
+++ b/Example/Tests/Coordinate3DTests.swift
@@ -1,5 +1,5 @@
 /*
- *   Coordinate3DTests.swift
+ *   Coordinate2DTests.swift
  *
  *   Copyright 2016 Tony Stone
  *
@@ -17,6 +17,54 @@
  *
  *   Created by Tony Stone on 2/10/16.
  */
-import Swift
+import XCTest
+@testable import GeoFeatures2
 
+class Coordinate3DTests: XCTestCase {
 
+    // MARK: Equal
+    
+    func testEqual_Zero_Dimension2()         { XCTAssertEqual(coordinateEquals((0.0,0.0,0.0), (0.0,0.0,0.0), dimension: 2), true) }
+    
+    func testEqual_Zero_Dimension3()         { XCTAssertEqual(coordinateEquals((0.0,0.0,0.0), (0.0,0.0,0.0), dimension: 3), true) }
+
+    func testEqual_One_Dimension2()          { XCTAssertEqual(coordinateEquals((1.0,1.0,1.0), (1.0,1.0,1.0), dimension: 2), true)  }
+    
+    func testEqual_One_Dimension3()          { XCTAssertEqual(coordinateEquals((1.0,1.0,1.0), (1.0,1.0,1.0), dimension: 3), true)  }
+    
+    func testEqual_Negative_Dimension2()     { XCTAssertEqual(coordinateEquals((-1.0,-1.0,-1.0), (-1.0,-1.0,-1.0), dimension: 2), true) }
+    
+    func testEqual_Negative_Dimension3()     { XCTAssertEqual(coordinateEquals((-1.0,-1.0,-1.0), (-1.0,-1.0,-1.0), dimension: 3), true) }
+    
+    func testEqual_Small_Dimension2()        { XCTAssertEqual(coordinateEquals((0.0000000000000000001,0.0000000000000000001,0.0000000000000000001), (0.0000000000000000001,0.0000000000000000001,0.0000000000000000001), dimension: 2), true) }
+    
+    func testEqual_Small_Dimension3()        { XCTAssertEqual(coordinateEquals((0.0000000000000000001,0.0000000000000000001,0.0000000000000000001), (0.0000000000000000001,0.0000000000000000001,0.0000000000000000001), dimension: 3), true) }
+    
+    func testEqual_Large_Dimension2()        { XCTAssertEqual(coordinateEquals((1000000000000000000.0,1000000000000000000.0,1000000000000000000.0), (1000000000000000000.0,1000000000000000000.0,1000000000000000000.0), dimension: 2), true)  }
+    
+    func testEqual_Large_Dimension3()        { XCTAssertEqual(coordinateEquals((1000000000000000000.0,1000000000000000000.0,1000000000000000000.0), (1000000000000000000.0,1000000000000000000.0,1000000000000000000.0), dimension: 3), true)  }
+    
+    
+    // MARK: Not Equal
+    
+    func testNotEqual_Zero_Dimension2()         { XCTAssertEqual(coordinateEquals((0.0,0.0,0.0),(0.0,0.0,1.0), dimension: 2), true) }
+    
+    func testNotEqual_Zero_Dimension3()         { XCTAssertEqual(coordinateEquals((0.0,0.0,0.0),(0.0,0.0,1.0), dimension: 3), false) }
+    
+    func testNotEqual_One_Dimension2()          { XCTAssertEqual(coordinateEquals((1.0,1.0,1.0),(1.0,1.0,0.0), dimension: 2), true)  }
+    
+    func testNotEqual_One_Dimension3()          { XCTAssertEqual(coordinateEquals((1.0,1.0,1.0),(1.0,1.0,0.0), dimension: 3), false)  }
+    
+    func testNotEqual_Negative_Dimension2()     { XCTAssertEqual(coordinateEquals((-1.0,-1.0,-1.0),(-1.0,-1.0,-2.0), dimension: 2), true)  }
+    
+    func testNotEqual_Negative_Dimension3()     { XCTAssertEqual(coordinateEquals((-1.0,-1.0,-1.0),(-1.0,-1.0,-2.0), dimension: 3), false)  }
+    
+    func testNotEqual_Small_Dimension2()        { XCTAssertEqual(coordinateEquals((0.0000000000000000001,0.0000000000000000001,0.0000000000000000001), (0.0000000000000000001,0.0000000000000000001,0.00000000000000000011), dimension: 2), true)  }
+    
+    func testNotEqual_Small_Dimension3()        { XCTAssertEqual(coordinateEquals((0.0000000000000000001,0.0000000000000000001,0.0000000000000000001), (0.0000000000000000001,0.0000000000000000001,0.00000000000000000011), dimension: 3), false)  }
+    
+    func testNotEqual_Large_Dimension2()        { XCTAssertEqual(coordinateEquals((1000000000000000000.0,1000000000000000000.0,1000000000000000000.0), (1000000000000000000.0,1000000000000000000.0,1200000000000000000.0), dimension: 2), true)  }
+    
+    func testNotEqual_Large_Dimension3()        { XCTAssertEqual(coordinateEquals((1000000000000000000.0,1000000000000000000.0,1000000000000000000.0), (1000000000000000000.0,1000000000000000000.0,1200000000000000000.0), dimension: 3), false)  }
+    
+}

--- a/Example/Tests/LineStringTests.swift
+++ b/Example/Tests/LineStringTests.swift
@@ -33,7 +33,7 @@ class LineStringTests: XCTestCase {
         XCTAssertEqual(
             (LineString(coordinates: [(10.0,10.0)]).elementsEqual([(10.0,10.0,Double.NaN)])
                 { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
-                    return lhs == rhs
+                    return coordinateEquals(lhs, rhs, dimension: 2)
             }
         ), true)
     }
@@ -44,7 +44,7 @@ class LineStringTests: XCTestCase {
         XCTAssertEqual(
             (LineString(coordinates: [(10.03,10.04)], precision: fixed).elementsEqual([(10.03,10.04,Double.NaN)])
                 { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
-                    return lhs == rhs
+                    return coordinateEquals(lhs, rhs, dimension: 2)
                 }
             ), true)
     }
@@ -55,7 +55,7 @@ class LineStringTests: XCTestCase {
         XCTAssertEqual(
             (LineString(coordinates: [(10.003,10.004)], precision: fixed).elementsEqual([(10.0,10.0,Double.NaN)])
                 { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
-                    return lhs == rhs
+                    return coordinateEquals(lhs, rhs, dimension: 2)
                 }
             ), true)
     }
@@ -65,7 +65,7 @@ class LineStringTests: XCTestCase {
         XCTAssertEqual(
             (LineString(coordinates: [(10.0,10.0,10.0)]).elementsEqual([(10.0,10.0,10.0)])
                 { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
-                    return lhs == rhs
+                    return coordinateEquals(lhs, rhs, dimension: 3)
                 }
             ), true)
     }
@@ -75,7 +75,7 @@ class LineStringTests: XCTestCase {
         XCTAssertEqual(
             (LineString(coordinates: [(10,10)]).elementsEqual([(10.0,10.0,Double.NaN)])
                 { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
-                    return lhs == rhs
+                    return coordinateEquals(lhs, rhs, dimension: 2)
                 }
             ), true)
     }
@@ -85,7 +85,7 @@ class LineStringTests: XCTestCase {
         XCTAssertEqual(
             (LineString(coordinates: [(10,10,10)]).elementsEqual([(10.0,10.0,10.0)])
                 { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
-                    return lhs == rhs
+                    return coordinateEquals(lhs, rhs, dimension: 3)
                 }
             ), true)
     }
@@ -95,7 +95,7 @@ class LineStringTests: XCTestCase {
     func testSubscript_Get () {
         let lineString = LineString(coordinates: [(10,10,10),(20,20,20)])
         
-        XCTAssertEqual(lineString[1] == (20,20,20), true)
+        XCTAssertEqual(coordinateEquals(lineString[1], (20,20,20), dimension: 3), true)
     }
     
     func testSubscript_Set () {
@@ -103,7 +103,7 @@ class LineStringTests: XCTestCase {
         
         lineString[1] = (10,10,10)
         
-        XCTAssertEqual(lineString[1] == (10,10,10), true)
+        XCTAssertEqual(coordinateEquals(lineString[1], (10,10,10), dimension: 3), true)
     }
     
     func testAppendContentsOf_LineString () {
@@ -124,7 +124,7 @@ class LineStringTests: XCTestCase {
         lineString2.appendContentsOf(array)
         
         XCTAssertEqual(lineString2.elementsEqual(array) { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
-            return lhs == rhs
+            return coordinateEquals(lineString2[1], (20,20,20), dimension: 3)
         }, true)
     }
     
@@ -159,7 +159,7 @@ class LineStringTests: XCTestCase {
         
         XCTAssertEqual(lineString.elementsEqual([(10.0,10.0,10.0)])
             { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
-                return lhs == rhs
+                return coordinateEquals(lhs, rhs, dimension:  3)
         }, true)
     }
 

--- a/Pod/Coordinate2D.swift
+++ b/Pod/Coordinate2D.swift
@@ -28,21 +28,29 @@ public typealias Coordinate2D = (x: Double, y: Double)
 
 //: Mark: Equatable
 
-func == <T: protocol<Equatable, FloatingPointType>> (tuple1:(T,T),tuple2:(T,T)) -> Bool {
+internal func coordinateEquals<T : protocol<Comparable, FloatingPointType>>(tuple1: (T,T), _ tuple2: (T,T)) -> Bool {
     return (tuple1.0 == tuple2.0) && (tuple1.1 == tuple2.1)
 }
 
-func != <T: protocol<Comparable, FloatingPointType>> (tuple1:(T,T),tuple2:(T,T)) -> Bool {
-    return (tuple1.0 != tuple2.0) || (tuple1.1 != tuple2.1)
+internal func coordinateEquals<T : protocol<Comparable, IntegerType>>(tuple1: (T,T), _ tuple2: (T,T), dimension: Int) -> Bool {
+    return (tuple1.0 == tuple2.0) && (tuple1.1 == tuple2.1)
 }
 
 //: Mark: Math
 
-func + (tuple1:(Double,Double),tuple2:(Double,Double)) -> (Double,Double) {
+internal func coordinateAdd(tuple1: (Double,Double), _ tuple2: (Double,Double)) -> (Double,Double)  {
     return (tuple1.0 + tuple2.0, tuple1.1 + tuple2.1)
 }
 
-func - (tuple1:(Double,Double),tuple2:(Double,Double)) -> (Double,Double) {
+internal func coordinateAdd(tuple1: (Int,Int), _ tuple2: (Int,Int)) -> (Int,Int)  {
+    return (tuple1.0 + tuple2.0, tuple1.1 + tuple2.1)
+}
+
+internal func coordinateSubtract(tuple1: (Double,Double), _ tuple2: (Double,Double)) -> (Double,Double) {
+    return (tuple1.0 - tuple2.0, tuple1.1 - tuple2.1)
+}
+
+internal func coordinateSubtract(tuple1: (Int,Int), _ tuple2: (Int,Int)) -> (Int,Int) {
     return (tuple1.0 - tuple2.0, tuple1.1 - tuple2.1)
 }
 

--- a/Pod/Coordinate3D.swift
+++ b/Pod/Coordinate3D.swift
@@ -28,20 +28,28 @@ public typealias Coordinate3D = (x: Double, y: Double, z: Double)
 
 //: Mark: Equatable
 
-func == <T: protocol<Equatable, FloatingPointType>> (tuple1:(T,T,T),tuple2:(T,T,T)) -> Bool {
-    return (tuple1.0 == tuple2.0) && (tuple1.1 == tuple2.1) && (tuple1.2.isNaN && tuple2.2.isNaN ? true : (tuple1.2 == tuple2.2))
+internal func coordinateEquals<T : protocol<Comparable, FloatingPointType>>(tuple1: (T,T,T), _ tuple2: (T,T,T), dimension: Int) -> Bool {
+    return (tuple1.0 == tuple2.0) && (tuple1.1 == tuple2.1) && (dimension == 3 ? (tuple1.2 == tuple2.2) : true)
 }
 
-func != <T: protocol<Comparable, FloatingPointType>> (tuple1:(T,T,T),tuple2:(T,T,T)) -> Bool {
-    return (tuple1.0 != tuple2.0) || (tuple1.1 != tuple2.1) || (tuple1.2.isNaN && tuple2.2.isNaN ? false : (tuple1.2 != tuple2.2))
+internal func coordinateEquals<T : protocol<Comparable, IntegerType>>(tuple1: (T,T,T), _ tuple2: (T,T,T), dimension: Int) -> Bool {
+    return (tuple1.0 == tuple2.0) && (tuple1.1 == tuple2.1) && (dimension == 3 ? (tuple1.2 == tuple2.2) : true)
 }
 
 //: Mark: Math
 
-func +(tuple1:(Double,Double,Double),tuple2:(Double,Double,Double)) -> (Double,Double,Double)  {
-    return (tuple1.0 + tuple2.0, tuple1.1 + tuple2.1, tuple1.2.isNaN || tuple2.2.isNaN ? Double.NaN : tuple1.2 + tuple2.2)
+internal func coordinateAdd(tuple1: (Double,Double,Double), _ tuple2: (Double,Double,Double), dimension: Int) -> (Double,Double,Double)  {
+    return (tuple1.0 + tuple2.0, tuple1.1 + tuple2.1, (dimension == 3 ? tuple1.2 + tuple2.2 : Double.NaN))
 }
 
-func - (tuple1:(Double,Double,Double),tuple2:(Double,Double,Double)) -> (Double,Double,Double) {
-    return (tuple1.0 - tuple2.0, tuple1.1 - tuple2.1, tuple1.2.isNaN || tuple2.2.isNaN ? Double.NaN : tuple1.2 - tuple2.2)
+internal func coordinateAdd(tuple1: (Int,Int,Int), _ tuple2: (Int,Int,Int), dimension: Int) -> (Int,Int,Int)  {
+    return (tuple1.0 + tuple2.0, tuple1.1 + tuple2.1, (dimension == 3 ? tuple1.2 + tuple2.2 : 0))
+}
+
+internal func coordinateSubtract(tuple1: (Double,Double,Double), _ tuple2: (Double,Double,Double), dimension: Int) -> (Double,Double,Double) {
+    return (tuple1.0 - tuple2.0, tuple1.1 - tuple2.1, (dimension == 3 ? tuple1.2 - tuple2.2 : Double.NaN))
+}
+
+internal func coordinateSubtract(tuple1: (Int,Int,Int), _ tuple2: (Int,Int,Int), dimension: Int) -> (Int,Int,Int) {
+    return (tuple1.0 - tuple2.0, tuple1.1 - tuple2.1, (dimension == 3 ? tuple1.2 - tuple2.2 : 0))
 }

--- a/Pod/LineString+GeometryType.swift
+++ b/Pod/LineString+GeometryType.swift
@@ -21,7 +21,6 @@ import Swift
 
 extension LineString /* GeometryType conformance */ {
 
-
     public func isEmpty() -> Bool {
         return self.count == 0
     }
@@ -29,7 +28,7 @@ extension LineString /* GeometryType conformance */ {
     public func equals(other: GeometryType) -> Bool {
         if let other = other as? LineString {
             return self.elementsEqual(other, isEquivalent: { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
-                return lhs == rhs
+                return coordinateEquals(lhs, rhs, dimension: self.dimension)
             })
         }
         return false

--- a/Pod/LinearRing+GeometryType.swift
+++ b/Pod/LinearRing+GeometryType.swift
@@ -28,7 +28,7 @@ extension LinearRing /* GeometryType conformance */ {
     public func equals(other: GeometryType) -> Bool {
         if let other = other as? LinearRing {
             return self.elementsEqual(other, isEquivalent: { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
-                return lhs == rhs
+                return coordinateEquals(lhs, rhs, dimension: self.dimension)
             })
         }
         return false

--- a/Pod/Point+GeometryType.swift
+++ b/Pod/Point+GeometryType.swift
@@ -17,7 +17,7 @@ extension Point /* GeometryType Conformance */ {
     public func equals(other: GeometryType) -> Bool {
         if let other = other as? Point {
             if self.dimension == other.dimension {
-                return self.x == other.x && self.x == other.y && other.dimension == 2 ? true : (self.z == other.z)
+                return coordinateEquals(self.coordinate, other.coordinate, dimension: self.dimension)
             }
         }
         return false

--- a/Pod/Point.swift
+++ b/Pod/Point.swift
@@ -32,7 +32,7 @@ public struct Point : GeometryType {
     public let precision: Precision
     public let coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem
     
-    private let coordinate: Coordinate3D
+    internal let coordinate: Coordinate3D
     
     /**
      * Initialize this Point with the coordinates


### PR DESCRIPTION
In order to apply equal to coordinates in a consistent way and be able to drive the number of dimensions tested, I rewrote the equals and math for coordinates to accept a dimension parameter.  They changed from operators to funcs with a name in order to facilitate that.
