### PR TITLE
Update LineString+Curve.swift

### DIFF
--- a/Geometry/LineString+Curve.swift
+++ b/Geometry/LineString+Curve.swift
@@ -32,9 +32,10 @@ extension LineString : Curve {
         if self.coordinateReferenceSystem is Cartesian {
             var generator = self.generate()
             
-            if let p1 = generator.next() {
+            if var p1 = generator.next() {
                 while let  p2 = generator.next() {
                     length += sqrt(pow(abs(p1.x - p2.x), 2) + pow(abs(p1.y - p2.y), 2) + (self.dimension == 3 ? pow(abs(p1.z - p2.z), 2) : 0))
+                    p1 = p2
                 }
             }
         }


### PR DESCRIPTION
- Fixed a bug where length will calculate based on the first coordinate for all subsequent coordinates.
