### PR TITLE
Fixing failure output messages in tests for collection types 

### DIFF
--- a/Example/Tests/CoordinateCollectionTests.swift.gyb
+++ b/Example/Tests/CoordinateCollectionTests.swift.gyb
@@ -73,13 +73,15 @@ class ${Self}_${FunctionQualifier}_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (${GeometryType}<${CoordinateType}>(elements: [${TestTuple0},${TestTuple1}], precision: precision, coordinateReferenceSystem: crs).elementsEqual([${CoordinateType}(tuple: ${ExpectedTuple0}), ${CoordinateType}(tuple: ${ExpectedTuple1})])
+        let geometry = ${GeometryType}<${CoordinateType}>(elements: [${TestTuple0},${TestTuple1}], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [${CoordinateType}(tuple: ${ExpectedTuple0}), ${CoordinateType}(tuple: ${ExpectedTuple1})]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: ${CoordinateType}, rhs: ${CoordinateType}) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -109,12 +111,13 @@ class ${Self}_${FunctionQualifier}_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [${CoordinateType}(tuple: ${ExpectedTuple0}), ${CoordinateType}(tuple: ${ExpectedTuple1})]
+
         geometry.append(contentsOf: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})])
         
-        XCTAssertEqual(geometry.elementsEqual([${CoordinateType}(tuple: ${ExpectedTuple0}), ${CoordinateType}(tuple: ${ExpectedTuple1})]) { (lhs: ${CoordinateType}, rhs: ${CoordinateType}) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: ${CoordinateType}, rhs: ${CoordinateType}) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -135,25 +138,26 @@ class ${Self}_${FunctionQualifier}_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [${CoordinateType}(tuple: ${ExpectedTuple0})]
+
         geometry.append(${TestTuple0})
         
-        XCTAssertEqual(geometry.elementsEqual([${CoordinateType}(tuple: ${ExpectedTuple0})])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: ${CoordinateType}, rhs: ${CoordinateType}) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [${CoordinateType}(tuple: ${ExpectedTuple1}), ${CoordinateType}(tuple: ${ExpectedTuple0}), ${CoordinateType}(tuple: ${ExpectedTuple1})]
+
         geometry.insert(${CoordinateType}(tuple: ${TestTuple1}), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([${CoordinateType}(tuple: ${ExpectedTuple1}), ${CoordinateType}(tuple: ${ExpectedTuple0}), ${CoordinateType}(tuple: ${ExpectedTuple1})])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: ${CoordinateType}, rhs: ${CoordinateType}) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {

--- a/Example/Tests/LineStringTests.swift
+++ b/Example/Tests/LineStringTests.swift
@@ -40,13 +40,15 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))])
+        let geometry = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -76,12 +78,13 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
+
         geometry.append(contentsOf: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))])
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]) { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -102,25 +105,26 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0))]
+
         geometry.append((x: 1.0, y: 1.0))
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2D(tuple: (x: 1.0, y: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2D(tuple: (x: 2.0, y: 2.0)), Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
+
         geometry.insert(Coordinate2D(tuple: (x: 2.0, y: 2.0)), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2D(tuple: (x: 2.0, y: 2.0)), Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {
@@ -144,13 +148,15 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (LineString<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))])
+        let geometry = LineString<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -180,12 +186,13 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
+
         geometry.append(contentsOf: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))])
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]) { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -206,25 +213,26 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))]
+
         geometry.append((x: 1.0, y: 1.0, m: 1.0))
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
+
         geometry.insert(Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {
@@ -248,13 +256,15 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (LineString<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))])
+        let geometry = LineString<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -284,12 +294,13 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
+
         geometry.append(contentsOf: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))])
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]) { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -310,25 +321,26 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))]
+
         geometry.append((x: 1.0, y: 1.0, z: 1.0))
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
+
         geometry.insert(Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {
@@ -352,13 +364,15 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (LineString<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))])
+        let geometry = LineString<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -388,12 +402,13 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
+
         geometry.append(contentsOf: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))])
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]) { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -414,25 +429,26 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))]
+
         geometry.append((x: 1.0, y: 1.0, z: 1.0, m: 1.0))
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
+
         geometry.insert(Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {
@@ -456,13 +472,15 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (LineString<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))])
+        let geometry = LineString<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -492,12 +510,13 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
+
         geometry.append(contentsOf: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))])
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]) { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -518,25 +537,26 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0))]
+
         geometry.append((x: 1.001, y: 1.001))
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2D(tuple: (x: 1.0, y: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2D(tuple: (x: 2.0, y: 2.0)), Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
+
         geometry.insert(Coordinate2D(tuple: (x: 2.002, y: 2.002)), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2D(tuple: (x: 2.0, y: 2.0)), Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {
@@ -560,13 +580,15 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (LineString<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))])
+        let geometry = LineString<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -596,12 +618,13 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
+
         geometry.append(contentsOf: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))])
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]) { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -622,25 +645,26 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))]
+
         geometry.append((x: 1.001, y: 1.001, m: 1.001))
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
+
         geometry.insert(Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002)), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {
@@ -664,13 +688,15 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (LineString<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))])
+        let geometry = LineString<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -700,12 +726,13 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
+
         geometry.append(contentsOf: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))])
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]) { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -726,25 +753,26 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))]
+
         geometry.append((x: 1.001, y: 1.001, z: 1.001))
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
+
         geometry.insert(Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002)), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {
@@ -768,13 +796,15 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (LineString<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))])
+        let geometry = LineString<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -804,12 +834,13 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
+
         geometry.append(contentsOf: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))])
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]) { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -830,25 +861,26 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))]
+
         geometry.append((x: 1.001, y: 1.001, z: 1.001, m: 1.001))
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
+
         geometry.insert(Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002)), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {

--- a/Example/Tests/LinearRingTests.swift
+++ b/Example/Tests/LinearRingTests.swift
@@ -40,13 +40,15 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))])
+        let geometry = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -76,12 +78,13 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
+
         geometry.append(contentsOf: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))])
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]) { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -102,25 +105,26 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0))]
+
         geometry.append((x: 1.0, y: 1.0))
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2D(tuple: (x: 1.0, y: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2D(tuple: (x: 2.0, y: 2.0)), Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
+
         geometry.insert(Coordinate2D(tuple: (x: 2.0, y: 2.0)), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2D(tuple: (x: 2.0, y: 2.0)), Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {
@@ -144,13 +148,15 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (LinearRing<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))])
+        let geometry = LinearRing<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -180,12 +186,13 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
+
         geometry.append(contentsOf: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))])
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]) { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -206,25 +213,26 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))]
+
         geometry.append((x: 1.0, y: 1.0, m: 1.0))
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
+
         geometry.insert(Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {
@@ -248,13 +256,15 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (LinearRing<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))])
+        let geometry = LinearRing<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -284,12 +294,13 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
+
         geometry.append(contentsOf: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))])
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]) { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -310,25 +321,26 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))]
+
         geometry.append((x: 1.0, y: 1.0, z: 1.0))
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
+
         geometry.insert(Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {
@@ -352,13 +364,15 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (LinearRing<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))])
+        let geometry = LinearRing<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -388,12 +402,13 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
+
         geometry.append(contentsOf: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))])
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]) { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -414,25 +429,26 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))]
+
         geometry.append((x: 1.0, y: 1.0, z: 1.0, m: 1.0))
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
+
         geometry.insert(Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {
@@ -456,13 +472,15 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (LinearRing<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))])
+        let geometry = LinearRing<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -492,12 +510,13 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
+
         geometry.append(contentsOf: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))])
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]) { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -518,25 +537,26 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0))]
+
         geometry.append((x: 1.001, y: 1.001))
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2D(tuple: (x: 1.0, y: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2D(tuple: (x: 2.0, y: 2.0)), Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
+
         geometry.insert(Coordinate2D(tuple: (x: 2.002, y: 2.002)), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2D(tuple: (x: 2.0, y: 2.0)), Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {
@@ -560,13 +580,15 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (LinearRing<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))])
+        let geometry = LinearRing<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -596,12 +618,13 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
+
         geometry.append(contentsOf: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))])
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]) { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -622,25 +645,26 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))]
+
         geometry.append((x: 1.001, y: 1.001, m: 1.001))
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
+
         geometry.insert(Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002)), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {
@@ -664,13 +688,15 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (LinearRing<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))])
+        let geometry = LinearRing<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -700,12 +726,13 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
+
         geometry.append(contentsOf: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))])
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]) { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -726,25 +753,26 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))]
+
         geometry.append((x: 1.001, y: 1.001, z: 1.001))
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
+
         geometry.insert(Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002)), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {
@@ -768,13 +796,15 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple() {
-    
-        XCTAssertEqual(
-            (LinearRing<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))])
+        let geometry = LinearRing<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
     
     func testSubscript_Get() {
@@ -804,12 +834,13 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array() {
         
         var geometry = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
+
         geometry.append(contentsOf: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))])
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]) { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals() {
@@ -830,25 +861,26 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend() {
         var geometry = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))]
+
         geometry.append((x: 1.001, y: 1.001, z: 1.001, m: 1.001))
         
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testInsert() {
         var geometry = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
+
         geometry.insert(Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002)), atIndex: 0)
 
-        XCTAssertEqual(geometry.elementsEqual([Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
                 return lhs == rhs
-            }, true)
-        
+            }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll() {

--- a/Example/Tests/MultiPointTests.swift
+++ b/Example/Tests/MultiPointTests.swift
@@ -40,13 +40,15 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple () {
-    
-        XCTAssertEqual(
-            (MultiPoint<Coordinate2D>(elements: [Point(coordinate: (x: 1.0, y: 1.0)),Point(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Point(coordinate: (x: 1.0, y: 1.0)),Point(coordinate: (x: 2.0, y: 2.0))])
+        let geometry = MultiPoint<Coordinate2D>(elements: [Point(coordinate: (x: 1.0, y: 1.0)),Point(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)),Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Point<Coordinate2D>, rhs: Point<Coordinate2D>) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
 
     func testSubscript_Get () {
@@ -76,12 +78,13 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array () {
         
         var geometry = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)),Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))]
+
         geometry.append(contentsOf: [Point(coordinate: (x: 1.0, y: 1.0)),Point(coordinate: (x: 2.0, y: 2.0))])
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: (x: 1.0, y: 1.0)),Point(coordinate: (x: 2.0, y: 2.0))]) { (lhs: Point<Coordinate2D>, rhs: Point<Coordinate2D>) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Point<Coordinate2D>, rhs: Point<Coordinate2D>) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals () {
@@ -102,13 +105,14 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend () {
         var geometry = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))]
+
         geometry.append(Point(coordinate: (x: 1.0, y: 1.0)))
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: (x: 1.0, y: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Point<Coordinate2D>, rhs: Point<Coordinate2D>) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll () {
@@ -132,13 +136,15 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple () {
-    
-        XCTAssertEqual(
-            (MultiPoint<Coordinate2DM>(elements: [Point(coordinate: (x: 1.0, y: 1.0, m: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, m: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, m: 2.0))])
+        let geometry = MultiPoint<Coordinate2DM>(elements: [Point(coordinate: (x: 1.0, y: 1.0, m: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)),Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Point<Coordinate2DM>, rhs: Point<Coordinate2DM>) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
 
     func testSubscript_Get () {
@@ -168,12 +174,13 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array () {
         
         var geometry = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)),Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))]
+
         geometry.append(contentsOf: [Point(coordinate: (x: 1.0, y: 1.0, m: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, m: 2.0))])
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, m: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, m: 2.0))]) { (lhs: Point<Coordinate2DM>, rhs: Point<Coordinate2DM>) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Point<Coordinate2DM>, rhs: Point<Coordinate2DM>) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals () {
@@ -194,13 +201,14 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend () {
         var geometry = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))]
+
         geometry.append(Point(coordinate: (x: 1.0, y: 1.0, m: 1.0)))
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, m: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Point<Coordinate2DM>, rhs: Point<Coordinate2DM>) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll () {
@@ -224,13 +232,15 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple () {
-    
-        XCTAssertEqual(
-            (MultiPoint<Coordinate3D>(elements: [Point(coordinate: (x: 1.0, y: 1.0, z: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, z: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, z: 2.0))])
+        let geometry = MultiPoint<Coordinate3D>(elements: [Point(coordinate: (x: 1.0, y: 1.0, z: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)),Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Point<Coordinate3D>, rhs: Point<Coordinate3D>) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
 
     func testSubscript_Get () {
@@ -260,12 +270,13 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array () {
         
         var geometry = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)),Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))]
+
         geometry.append(contentsOf: [Point(coordinate: (x: 1.0, y: 1.0, z: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, z: 2.0))])
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, z: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, z: 2.0))]) { (lhs: Point<Coordinate3D>, rhs: Point<Coordinate3D>) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Point<Coordinate3D>, rhs: Point<Coordinate3D>) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals () {
@@ -286,13 +297,14 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend () {
         var geometry = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))]
+
         geometry.append(Point(coordinate: (x: 1.0, y: 1.0, z: 1.0)))
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, z: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Point<Coordinate3D>, rhs: Point<Coordinate3D>) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll () {
@@ -316,13 +328,15 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple () {
-    
-        XCTAssertEqual(
-            (MultiPoint<Coordinate3DM>(elements: [Point(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))])
+        let geometry = MultiPoint<Coordinate3DM>(elements: [Point(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)),Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Point<Coordinate3DM>, rhs: Point<Coordinate3DM>) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
 
     func testSubscript_Get () {
@@ -352,12 +366,13 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array () {
         
         var geometry = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)),Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
+
         geometry.append(contentsOf: [Point(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))])
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]) { (lhs: Point<Coordinate3DM>, rhs: Point<Coordinate3DM>) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Point<Coordinate3DM>, rhs: Point<Coordinate3DM>) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals () {
@@ -378,13 +393,14 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend () {
         var geometry = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))]
+
         geometry.append(Point(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)))
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Point<Coordinate3DM>, rhs: Point<Coordinate3DM>) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll () {
@@ -408,13 +424,15 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple () {
-    
-        XCTAssertEqual(
-            (MultiPoint<Coordinate2D>(elements: [Point(coordinate: (x: 1.001, y: 1.001)),Point(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Point(coordinate: (x: 1.0, y: 1.0)),Point(coordinate: (x: 2.0, y: 2.0))])
+        let geometry = MultiPoint<Coordinate2D>(elements: [Point(coordinate: (x: 1.001, y: 1.001)),Point(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)),Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Point<Coordinate2D>, rhs: Point<Coordinate2D>) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
 
     func testSubscript_Get () {
@@ -444,12 +462,13 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array () {
         
         var geometry = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)),Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))]
+
         geometry.append(contentsOf: [Point(coordinate: (x: 1.001, y: 1.001)),Point(coordinate: (x: 2.002, y: 2.002))])
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: (x: 1.0, y: 1.0)),Point(coordinate: (x: 2.0, y: 2.0))]) { (lhs: Point<Coordinate2D>, rhs: Point<Coordinate2D>) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Point<Coordinate2D>, rhs: Point<Coordinate2D>) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals () {
@@ -470,13 +489,14 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend () {
         var geometry = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))]
+
         geometry.append(Point(coordinate: (x: 1.001, y: 1.001)))
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: (x: 1.0, y: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Point<Coordinate2D>, rhs: Point<Coordinate2D>) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll () {
@@ -500,13 +520,15 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple () {
-    
-        XCTAssertEqual(
-            (MultiPoint<Coordinate2DM>(elements: [Point(coordinate: (x: 1.001, y: 1.001, m: 1.001)),Point(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, m: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, m: 2.0))])
+        let geometry = MultiPoint<Coordinate2DM>(elements: [Point(coordinate: (x: 1.001, y: 1.001, m: 1.001)),Point(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)),Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Point<Coordinate2DM>, rhs: Point<Coordinate2DM>) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
 
     func testSubscript_Get () {
@@ -536,12 +558,13 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array () {
         
         var geometry = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)),Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))]
+
         geometry.append(contentsOf: [Point(coordinate: (x: 1.001, y: 1.001, m: 1.001)),Point(coordinate: (x: 2.002, y: 2.002, m: 2.002))])
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, m: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, m: 2.0))]) { (lhs: Point<Coordinate2DM>, rhs: Point<Coordinate2DM>) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Point<Coordinate2DM>, rhs: Point<Coordinate2DM>) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals () {
@@ -562,13 +585,14 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend () {
         var geometry = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))]
+
         geometry.append(Point(coordinate: (x: 1.001, y: 1.001, m: 1.001)))
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, m: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Point<Coordinate2DM>, rhs: Point<Coordinate2DM>) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll () {
@@ -592,13 +616,15 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple () {
-    
-        XCTAssertEqual(
-            (MultiPoint<Coordinate3D>(elements: [Point(coordinate: (x: 1.001, y: 1.001, z: 1.001)),Point(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, z: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, z: 2.0))])
+        let geometry = MultiPoint<Coordinate3D>(elements: [Point(coordinate: (x: 1.001, y: 1.001, z: 1.001)),Point(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)),Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Point<Coordinate3D>, rhs: Point<Coordinate3D>) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
 
     func testSubscript_Get () {
@@ -628,12 +654,13 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array () {
         
         var geometry = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)),Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))]
+
         geometry.append(contentsOf: [Point(coordinate: (x: 1.001, y: 1.001, z: 1.001)),Point(coordinate: (x: 2.002, y: 2.002, z: 2.002))])
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, z: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, z: 2.0))]) { (lhs: Point<Coordinate3D>, rhs: Point<Coordinate3D>) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Point<Coordinate3D>, rhs: Point<Coordinate3D>) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals () {
@@ -654,13 +681,14 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend () {
         var geometry = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))]
+
         geometry.append(Point(coordinate: (x: 1.001, y: 1.001, z: 1.001)))
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, z: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Point<Coordinate3D>, rhs: Point<Coordinate3D>) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll () {
@@ -684,13 +712,15 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     }
     
     func testInit_Tuple () {
-    
-        XCTAssertEqual(
-            (MultiPoint<Coordinate3DM>(elements: [Point(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)),Point(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))])
+        let geometry = MultiPoint<Coordinate3DM>(elements: [Point(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)),Point(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)),Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Point<Coordinate3DM>, rhs: Point<Coordinate3DM>) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
 
     func testSubscript_Get () {
@@ -720,12 +750,13 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     func testAppend_Array () {
         
         var geometry = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)),Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
+
         geometry.append(contentsOf: [Point(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)),Point(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))])
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)),Point(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]) { (lhs: Point<Coordinate3DM>, rhs: Point<Coordinate3DM>) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Point<Coordinate3DM>, rhs: Point<Coordinate3DM>) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals () {
@@ -746,13 +777,14 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests : XCTestCase {
     
     func testAppend () {
         var geometry = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))]
+
         geometry.append(Point(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)))
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Point<Coordinate3DM>, rhs: Point<Coordinate3DM>) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll () {

--- a/Example/Tests/MultiPointTests.swift.gyb
+++ b/Example/Tests/MultiPointTests.swift.gyb
@@ -73,13 +73,15 @@ class ${Self}_${FunctionQualifier}_Tests : XCTestCase {
     }
     
     func testInit_Tuple () {
-    
-        XCTAssertEqual(
-            (MultiPoint<${CoordinateType}>(elements: [Point(coordinate: ${TestTuple0}),Point(coordinate: ${TestTuple1})], precision: precision, coordinateReferenceSystem: crs).elementsEqual([Point(coordinate: ${ExpectedTuple0}),Point(coordinate: ${ExpectedTuple1})])
+        let geometry = MultiPoint<${CoordinateType}>(elements: [Point(coordinate: ${TestTuple0}),Point(coordinate: ${TestTuple1})], precision: precision, coordinateReferenceSystem: crs)
+        let expected = [Point<${CoordinateType}>(coordinate: ${ExpectedTuple0}),Point<${CoordinateType}>(coordinate: ${ExpectedTuple1})]
+
+        XCTAssertTrue(
+            (geometry.elementsEqual(expected)
                 { (lhs: Point<${CoordinateType}>, rhs: Point<${CoordinateType}>) -> Bool in
                     return lhs == rhs
             }
-        ), true)
+        ), "\(geometry) is not equal to \(expected)")
     }
 
     func testSubscript_Get () {
@@ -109,12 +111,13 @@ class ${Self}_${FunctionQualifier}_Tests : XCTestCase {
     func testAppend_Array () {
         
         var geometry = MultiPoint<${CoordinateType}>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<${CoordinateType}>(coordinate: ${ExpectedTuple0}),Point<${CoordinateType}>(coordinate: ${ExpectedTuple1})]
+
         geometry.append(contentsOf: [Point(coordinate: ${TestTuple0}),Point(coordinate: ${TestTuple1})])
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: ${ExpectedTuple0}),Point(coordinate: ${ExpectedTuple1})]) { (lhs: Point<${CoordinateType}>, rhs: Point<${CoordinateType}>) -> Bool in
+        XCTAssertTrue(geometry.elementsEqual(expected) { (lhs: Point<${CoordinateType}>, rhs: Point<${CoordinateType}>) -> Bool in
             return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testEquals () {
@@ -135,13 +138,14 @@ class ${Self}_${FunctionQualifier}_Tests : XCTestCase {
     
     func testAppend () {
         var geometry = MultiPoint<${CoordinateType}>(precision: precision, coordinateReferenceSystem: crs)
-        
+        let expected = [Point<${CoordinateType}>(coordinate: ${ExpectedTuple0})]
+
         geometry.append(Point(coordinate: ${TestTuple0}))
         
-        XCTAssertEqual(geometry.elementsEqual([Point(coordinate: ${ExpectedTuple0})])
+        XCTAssertTrue(geometry.elementsEqual(expected)
             { (lhs: Point<${CoordinateType}>, rhs: Point<${CoordinateType}>) -> Bool in
                 return lhs == rhs
-        }, true)
+        }, "\(geometry) is not equal to \(expected)")
     }
 
     func testRemoveAll () {


### PR DESCRIPTION
Fixing failure output messages in tests for collection types bringing them inline with the Unit Test Requirements.
