### PR TITLE
Move Geometry Conformance

### DIFF
--- a/Geometry/CoordinateCollection.swift.gyb
+++ b/Geometry/CoordinateCollection.swift.gyb
@@ -33,7 +33,7 @@ import Swift
     A ${Self} is a Curve with linear interpolation between Coordinates. Each consecutive pair of
     Coordinates defines a Line segment.
  */
-public struct ${Self}<CoordinateType : protocol<Coordinate, CopyConstructable>> : Geometry {
+public struct ${Self}<CoordinateType : protocol<Coordinate, CopyConstructable>> {
 
     public let precision: Precision
     public let coordinateReferenceSystem: CoordinateReferenceSystem

--- a/Geometry/GeometryCollection+Geometry.swift
+++ b/Geometry/GeometryCollection+Geometry.swift
@@ -21,7 +21,7 @@ import Swift
 
 // MARK:  Geometry conformance
 
-extension GeometryCollection /* Geometry conformance */ {
+extension GeometryCollection : Geometry  {
     
     public func isEmpty() -> Bool {
         return self.count == 0

--- a/Geometry/GeometryCollection.swift
+++ b/Geometry/GeometryCollection.swift
@@ -35,7 +35,7 @@ import Swift
     All the elements in a GeometryCollection shall be in the same Spatial Reference System. This is also the Spatial Reference System for the GeometryCollection.
  */
 
-public struct GeometryCollection : Geometry  {
+public struct GeometryCollection {
         
     public typealias Element = Geometry
     

--- a/Geometry/GeometryCollection.swift.gyb
+++ b/Geometry/GeometryCollection.swift.gyb
@@ -36,11 +36,11 @@ import Swift
  */
 
 %if CoordinateSpecialized == 'true':
-public struct ${Self}<CoordinateType : protocol<Coordinate, CopyConstructable>> : Geometry  {
+public struct ${Self}<CoordinateType : protocol<Coordinate, CopyConstructable>> {
 
     public typealias Element = ${Element}<CoordinateType>
 %else:
-public struct ${Self} : Geometry  {
+public struct ${Self} {
         
     public typealias Element = ${Element}
 %end

--- a/Geometry/LineString+Geometry.swift
+++ b/Geometry/LineString+Geometry.swift
@@ -19,7 +19,7 @@
  */
 import Swift
 
-extension LineString /* Geometry conformance */ {
+extension LineString : Geometry  {
 
     public func isEmpty() -> Bool {
         return self.count == 0

--- a/Geometry/LineString.swift
+++ b/Geometry/LineString.swift
@@ -33,7 +33,7 @@ import Swift
     A LineString is a Curve with linear interpolation between Coordinates. Each consecutive pair of
     Coordinates defines a Line segment.
  */
-public struct LineString<CoordinateType : protocol<Coordinate, CopyConstructable>> : Geometry {
+public struct LineString<CoordinateType : protocol<Coordinate, CopyConstructable>> {
 
     public let precision: Precision
     public let coordinateReferenceSystem: CoordinateReferenceSystem

--- a/Geometry/LinearRing+Geometry.swift
+++ b/Geometry/LinearRing+Geometry.swift
@@ -19,7 +19,7 @@
  */
 import Swift
 
-extension LinearRing /* Geometry conformance */ {
+extension LinearRing : Geometry  {
     
     public func isEmpty() -> Bool {
         return self.count == 0

--- a/Geometry/LinearRing.swift
+++ b/Geometry/LinearRing.swift
@@ -33,7 +33,7 @@ import Swift
     A LinearRing is a Curve with linear interpolation between Coordinates. Each consecutive pair of
     Coordinates defines a Line segment.
  */
-public struct LinearRing<CoordinateType : protocol<Coordinate, CopyConstructable>> : Geometry {
+public struct LinearRing<CoordinateType : protocol<Coordinate, CopyConstructable>> {
 
     public let precision: Precision
     public let coordinateReferenceSystem: CoordinateReferenceSystem

--- a/Geometry/MultiLineString+Geometry.swift
+++ b/Geometry/MultiLineString+Geometry.swift
@@ -19,7 +19,7 @@
  */
 import Swift
 
-extension MultiLineString  /* Geometry conformance */  {
+extension MultiLineString : Geometry  {
 
     public func isEmpty() -> Bool {
         return self.count == 0

--- a/Geometry/MultiLineString.swift
+++ b/Geometry/MultiLineString.swift
@@ -35,7 +35,7 @@ import Swift
     All the elements in a MultiLineString shall be in the same Spatial Reference System. This is also the Spatial Reference System for the MultiLineString.
  */
 
-public struct MultiLineString<CoordinateType : protocol<Coordinate, CopyConstructable>> : Geometry  {
+public struct MultiLineString<CoordinateType : protocol<Coordinate, CopyConstructable>> {
 
     public typealias Element = LineString<CoordinateType>
     

--- a/Geometry/MultiPoint+Geometry.swift
+++ b/Geometry/MultiPoint+Geometry.swift
@@ -19,7 +19,7 @@
  */
 import Swift
 
-extension MultiPoint  /* Geometry conformance */  {
+extension MultiPoint : Geometry  {
     
     public func isEmpty() -> Bool {
         return self.count == 0

--- a/Geometry/MultiPoint.swift
+++ b/Geometry/MultiPoint.swift
@@ -35,7 +35,7 @@ import Swift
     All the elements in a MultiPoint shall be in the same Spatial Reference System. This is also the Spatial Reference System for the MultiPoint.
  */
 
-public struct MultiPoint<CoordinateType : protocol<Coordinate, CopyConstructable>> : Geometry  {
+public struct MultiPoint<CoordinateType : protocol<Coordinate, CopyConstructable>> {
 
     public typealias Element = Point<CoordinateType>
     

--- a/Geometry/MultiPolygon+Geometry.swift
+++ b/Geometry/MultiPolygon+Geometry.swift
@@ -19,7 +19,7 @@
  */
 import Swift
 
-extension MultiPolygon  /* Geometry conformance */  {
+extension MultiPolygon : Geometry {
     
     public func isEmpty() -> Bool {
         return self.count == 0

--- a/Geometry/MultiPolygon.swift
+++ b/Geometry/MultiPolygon.swift
@@ -35,7 +35,7 @@ import Swift
     All the elements in a MultiPolygon shall be in the same Spatial Reference System. This is also the Spatial Reference System for the MultiPolygon.
  */
 
-public struct MultiPolygon<CoordinateType : protocol<Coordinate, CopyConstructable>> : Geometry  {
+public struct MultiPolygon<CoordinateType : protocol<Coordinate, CopyConstructable>> {
 
     public typealias Element = Polygon<CoordinateType>
     

--- a/Geometry/Point+Geometry.swift
+++ b/Geometry/Point+Geometry.swift
@@ -8,7 +8,7 @@
 
 import Swift
 
-extension Point /* Geometry Conformance */ {
+extension Point : Geometry {
 
     public func isEmpty() -> Bool {
         return false    // Point can never be empty

--- a/Geometry/Point.swift
+++ b/Geometry/Point.swift
@@ -26,7 +26,7 @@ import Swift
  x coordinate value, a y coordinate value. If called for by the associated Spatial Reference System, it may also
  have coordinate values for z.
  */
-public struct Point<CoordinateType : protocol<Coordinate, CopyConstructable>> : Geometry {
+public struct Point<CoordinateType : protocol<Coordinate, CopyConstructable>> {
     
     public let precision: Precision
     public let coordinateReferenceSystem: CoordinateReferenceSystem

--- a/Geometry/Polygon+Geometry.swift
+++ b/Geometry/Polygon+Geometry.swift
@@ -19,7 +19,7 @@
  */
 import Swift
 
-extension Polygon /* Geometry conformance */ {
+extension Polygon : Geometry  {
 
     public func isEmpty() -> Bool {
         return self.outerRing.count == 0

--- a/Geometry/Polygon.swift
+++ b/Geometry/Polygon.swift
@@ -27,7 +27,7 @@ import Swift
     - requires: isSimple == true
     - requires: isClosed == true for "outerRing" and all "innerRings"
  */
-public struct Polygon<CoordinateType : protocol<Coordinate, CopyConstructable>> : Geometry {
+public struct Polygon<CoordinateType : protocol<Coordinate, CopyConstructable>>  {
     
     public typealias RingType = LinearRing<CoordinateType>
     


### PR DESCRIPTION
Swift 2.2 fixed an issue that forced us to have the main class conform to Geometry.   We're moving this conformance to the extension now where it should have been.
