### PR TITLE
Removing forced cast from String to NSString

### DIFF
--- a/Source/Geometry/Tokenizer.swift
+++ b/Source/Geometry/Tokenizer.swift
@@ -29,7 +29,7 @@ internal class Tokenizer<T : Token> {
     var line = 0
     var column = 0
 
-    var matchString: String { get { return (stringStream as! NSString).substring(with: matchRange) } }
+    var matchString: String { get { return (stringStream as NSString).substring(with: matchRange) } }
     
     private var stringStream: String
     private var matchRange: NSRange
@@ -59,7 +59,7 @@ internal class Tokenizer<T : Token> {
             matchRange.location += range.length
             matchRange.length   -= range.length
             
-            return (stringStream as! NSString).substring(with: range)
+            return (stringStream as NSString).substring(with: range)
         }
         return nil
     }


### PR DESCRIPTION
Removing forced cast from String to NSString as it's no longer needed (always succeeds).
