### PR TITLE
Changes to move up to the Swift Snapshot 2016-05-31-a.

### DIFF
--- a/Source/Geometry/CoordinateCollection.swift.gyb
+++ b/Source/Geometry/CoordinateCollection.swift.gyb
@@ -317,7 +317,7 @@ extension ${Self} where CoordinateType : protocol<TupleConvertable, CopyConstruc
         
         self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
         
-        self.storage.resize(numericCast(elements.count))
+        self.reserveCapacity(numericCast(elements.count))
         
         var Iterator = elements.makeIterator()
         

--- a/Source/Geometry/LineString.swift
+++ b/Source/Geometry/LineString.swift
@@ -317,7 +317,7 @@ extension LineString where CoordinateType : protocol<TupleConvertable, CopyConst
         
         self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
         
-        self.storage.resize(numericCast(elements.count))
+        self.reserveCapacity(numericCast(elements.count))
         
         var Iterator = elements.makeIterator()
         

--- a/Source/Geometry/LinearRing.swift
+++ b/Source/Geometry/LinearRing.swift
@@ -317,7 +317,7 @@ extension LinearRing where CoordinateType : protocol<TupleConvertable, CopyConst
         
         self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
         
-        self.storage.resize(numericCast(elements.count))
+        self.reserveCapacity(numericCast(elements.count))
         
         var Iterator = elements.makeIterator()
         

--- a/Source/Geometry/Tokenizer.swift
+++ b/Source/Geometry/Tokenizer.swift
@@ -18,6 +18,7 @@
  *   Created by Tony Stone on 5/4/16.
  */
 import Swift
+import Foundation
 
 internal protocol Token {
     func match(string: String, matchRange: NSRange) -> NSRange
@@ -29,7 +30,12 @@ internal class Tokenizer<T : Token> {
     var line = 0
     var column = 0
 
+    // FIXME: This is temporary until the the following known issue is fixed. https://github.com/apple/swift-corelibs-foundation/blob/master/Docs/Issues.md#known-issues
+#if os(Linux) || os(FreeBSD)
+    var matchString: String { get { return stringStream.bridge().substring(with: matchRange) } }
+#else
     var matchString: String { get { return (stringStream as NSString).substring(with: matchRange) } }
+#endif
     
     private var stringStream: String
     private var matchRange: NSRange
@@ -59,7 +65,12 @@ internal class Tokenizer<T : Token> {
             matchRange.location += range.length
             matchRange.length   -= range.length
             
+    // FIXME: This is temporary until the the following known issue is fixed. https://github.com/apple/swift-corelibs-foundation/blob/master/Docs/Issues.md#known-issues
+#if os(Linux) || os(FreeBSD)
+            return stringStream.bridge().substring(with: range)
+#else
             return (stringStream as NSString).substring(with: range)
+#endif
         }
         return nil
     }

--- a/Source/Geometry/WKTReader.swift
+++ b/Source/Geometry/WKTReader.swift
@@ -18,6 +18,7 @@
  *   Created by Tony Stone on 2/10/16.
  */
 import Swift
+import Foundation
 
 public enum ParseError : ErrorProtocol  {
     case UnsupportedType(String)

--- a/Tests/Geometry/WKTReaderTests.swift
+++ b/Tests/Geometry/WKTReaderTests.swift
@@ -59,7 +59,7 @@ class WKTReader_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
     func testRead_Point_Invalid_WhiteSpace() {
         
         do {
-            try wktReader.read(wkt: "POINT  (   1.0     1.0   ) ")
+            let _ = try wktReader.read(wkt: "POINT  (   1.0     1.0   ) ")
             
             XCTFail("Parsing failed")
             
@@ -97,7 +97,7 @@ class WKTReader_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
     func testRead_Point_InvalidCoordinate() {
         
         do {
-            try wktReader.read(wkt: "POINT (1.01.0)")
+            let _ = try wktReader.read(wkt: "POINT (1.01.0)")
             
             XCTFail("Parsing failed")
             
@@ -135,7 +135,7 @@ class WKTReader_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
     func testRead_MultiPoint_Invalid_MissingClosingParen() {
         
         do {
-            try wktReader.read(wkt: "MULTIPOINT ((1.0 2.0)")
+            let _ = try wktReader.read(wkt: "MULTIPOINT ((1.0 2.0)")
             
             XCTFail("Parsing failed")
             
@@ -161,7 +161,7 @@ class WKTReader_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
     func testRead_MultiLineString_Invalid_MissingCLosingParen() {
         
         do {
-            try wktReader.read(wkt: "MULTILINESTRING ((1.0 1.0, 2.0 2.0, 3.0 3.0), (4.0 4.0, 5.0 5.0, 6.0 6.0)")
+            let _ = try wktReader.read(wkt: "MULTILINESTRING ((1.0 1.0, 2.0 2.0, 3.0 3.0), (4.0 4.0, 5.0 5.0, 6.0 6.0)")
             
             XCTFail("Parsing failed")
             
@@ -218,7 +218,7 @@ class WKTReader_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
     func testRead_Polygon_MultipleOuterRings_Invalid_MissingComma() {
         
         do {
-            try wktReader.read(wkt: "MULTILINESTRING ((1.0 1.0, 2.0 2.0, 3.0 3.0), (4.0 4.0, 5.0 5.0, 6.0 6.0)")
+            let _ = try wktReader.read(wkt: "MULTILINESTRING ((1.0 1.0, 2.0 2.0, 3.0 3.0), (4.0 4.0, 5.0 5.0, 6.0 6.0)")
             
             XCTFail("Parsing failed")
             

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ sourceName=""
 sourceDirectory=""
 
 swiftRelease=false
-swiftVersion="2016-05-09-a"
+swiftVersion="2016-05-31-a"
 
 options = GetoptLong.new(
     [ '--swift-version', GetoptLong::OPTIONAL_ARGUMENT ],


### PR DESCRIPTION
Note: this snapshot broke our WKT parser on Linux platforms due to the Foundation implementation.  The code compiles but the WKT parses to nothing on Linux.
