### PR TITLE
Revert "Switching swiftlint from using overridden values

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,8 +25,17 @@ opt_in_rules:
   - private_outlet
   - redundant_nil_coalesing
 
+closing_brace:
+  severity: error
+
+closure_spacing:
+  severity: error
+
 colon:
   flexible_right_spacing: true
+  severity: error
+
+control_statement:
   severity: error
 
 cyclomatic_complexity:
@@ -41,9 +50,86 @@ function_body_length:
   warning: 400
   error: 100
 
+function_parameter_count:
+  warning: 5
+  error: 8
+
+leading_whitespace:
+  severity: error
+
+legacy_cggeometry_functions:
+  severity: error
+
+legacy_constant:
+  severity: error
+
+legacy_constructor:
+  severity: error
+
+legacy_nsgeometry_functions:
+  severity: error
+
+line_length:
+  warning: 100
+  error: 200
+
+mark:
+  severity: error
+
+nesting:
+  severity: error
+
+opening_brace:
+  severity: error
+
+operator_whitespace:
+  severity: error
+
+private_outlet:
+  severity: error
+
+private_unit_test:
+  severity:
+    error: XCTestCase
+
+redundant_nil_coalesing:
+  severity: error
+
+return_arrow_whitespace:
+  severity: error
+
+statement_position:
+  severity: error
+
+todo:
+  severity: warning
+
+trailing_newline:
+  severity: error
+
+trailing_semicolon:
+  severity: error
+
+trailing_whitespace:
+  severity:
+    warning:
+      ignores_empty_lines: false
+      ignores_comments: true
+
 type_body_length:
   warning: 300
   error: 450
+
+type_name:
+  min_length:
+    warning: 3
+    error: 0
+  max_length:
+    warning: 40
+    error: 1000
+
+valid_docs:
+  severity: error
 
 variable_name:
   min_length: # Note: it important that we allow variable names like x, y, z, m so our min length for error is 0
@@ -52,5 +138,8 @@ variable_name:
   max_length:
     warning: 40
     error: 60
+
+vertical_whitespace:
+  severity: error
 
 reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit)

--- a/Example/GeoFeatures.xcodeproj/project.pbxproj
+++ b/Example/GeoFeatures.xcodeproj/project.pbxproj
@@ -595,7 +595,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint lint --strict --path ../\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint lint --path ../\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
 		EA940DC31DDAB0B700F7DA69 /* [Run Script] Generate XCTest Runner files */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -20,6 +20,19 @@ opt_in_rules:
   - private_outlet
   - redundant_nil_coalesing
 
+closing_brace:
+  severity: error
+
+closure_spacing:
+  severity: error
+
+colon:
+  flexible_right_spacing: true
+  severity: error
+
+control_statement:
+  severity: error
+
 cyclomatic_complexity:
   warning: 30
   error: 50
@@ -32,6 +45,72 @@ function_body_length:
   warning: 400
   error: 100
 
+function_parameter_count:
+  warning: 5
+  error: 8
+
+leading_whitespace:
+  severity: error
+
+legacy_cggeometry_functions:
+  severity: error
+
+legacy_constant:
+  severity: error
+
+legacy_constructor:
+  severity: error
+
+legacy_nsgeometry_functions:
+  severity: error
+
+line_length:
+  warning: 100
+  error: 200
+
+mark:
+  severity: error
+
+nesting:
+  severity: error
+
+opening_brace:
+  severity: error
+
+operator_whitespace:
+  severity: error
+
+private_outlet:
+  severity: error
+
+private_unit_test:
+  severity:
+    error: XCTestCase
+
+redundant_nil_coalesing:
+  severity: error
+
+return_arrow_whitespace:
+  severity: error
+
+statement_position:
+  severity: error
+
+todo:
+  severity: warning
+
+trailing_newline:
+  severity: error
+
+trailing_semicolon:
+  severity: error
+
+trailing_whitespace:
+  severity:
+    warning:
+      ignores_empty_lines: false
+      ignores_comments: true
+
 type_name:
   min_length:
     warning: 3
@@ -40,6 +119,9 @@ type_name:
     warning: 40
     error: 1000
 
+valid_docs:
+  severity: error
+
 variable_name:
   min_length:
     warning: 3
@@ -47,5 +129,8 @@ variable_name:
   max_length:
     warning: 40
     error: 60
+
+vertical_whitespace:
+  severity: error
 
 reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit)

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ dependencies:
 
 test:
   override:
-    - swiftlint lint --strict
+    - swiftlint lint
     - set -o pipefail &&
       xcodebuild
         CODE_SIGNING_REQUIRED=NO


### PR DESCRIPTION
These changes caused confusion since warnings are displayed in Xcode as warnings but the build fails anyway.  Reverting will cause warnings to be warnings and only errors specified to fail the build.

This reverts commit d2f5df54ce8a1b529998e005ab0a3b96df41f9bb.