### PR TITLE
Changing CoordinateReferenceSystem to CoordinateSystem so as not to c…

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		1C66F6A686420CE0EA7096B0 /* Geometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BBDE7CF4917B38AB1C2B26 /* Geometry.swift */; };
 		21FFC53BB24D33F4D9106CBE /* FixedPrecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B651C7DAA87CB3362BA96F9 /* FixedPrecision.swift */; };
 		227919937552CCD337E0972C /* GeoFeatures-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 07981CBA9828F76301EE2066 /* GeoFeatures-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2D6686C8B35B5435179DE0CB /* CoordinateReferenceSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8422DDEC61CC16DB661E7E2 /* CoordinateReferenceSystem.swift */; };
+		2D6686C8B35B5435179DE0CB /* CoordinateSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8422DDEC61CC16DB661E7E2 /* CoordinateSystem.swift */; };
 		2E997CEF8A41C0FF7BE41C42 /* GeometryCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B893A61BED64A42EB7DBBDA /* GeometryCollection.swift */; };
 		343907869216ACCF5BD091CE /* GeoFeatures-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = EA465432339064F4FEDFF3E9 /* GeoFeatures-dummy.m */; };
 		403CAD10DBBEEDBE646BDA92 /* LineString+Geometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6B4B7443587F27DD391B2AB /* LineString+Geometry.swift */; };
@@ -146,7 +146,7 @@
 		D41288F255AF93A0186927AA /* LinearRing+Geometry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LinearRing+Geometry.swift"; sourceTree = "<group>"; };
 		D480739D2031C8B4448AEE3F /* Coordinate3DM.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Coordinate3DM.swift; sourceTree = "<group>"; };
 		D4DFB5DA09E9B37E106AB070 /* TupleConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TupleConvertible.swift; sourceTree = "<group>"; };
-		D8422DDEC61CC16DB661E7E2 /* CoordinateReferenceSystem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CoordinateReferenceSystem.swift; sourceTree = "<group>"; };
+		D8422DDEC61CC16DB661E7E2 /* CoordinateSystem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CoordinateSystem.swift; sourceTree = "<group>"; };
 		DD4B4C6B40ED8724284AD15B /* WKTReader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WKTReader.swift; sourceTree = "<group>"; };
 		DEF5EAA16F8CB925DB4E4D15 /* Polygon+Surface.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Polygon+Surface.swift"; sourceTree = "<group>"; };
 		E27CAA8637CA48CF5FDCFF04 /* FloatingPrecision.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FloatingPrecision.swift; sourceTree = "<group>"; };
@@ -200,7 +200,7 @@
 				329D05CEA295E51B827C83A4 /* Coordinate2DM.swift */,
 				A150ACE235FD788BC5787384 /* Coordinate3D.swift */,
 				D480739D2031C8B4448AEE3F /* Coordinate3DM.swift */,
-				D8422DDEC61CC16DB661E7E2 /* CoordinateReferenceSystem.swift */,
+				D8422DDEC61CC16DB661E7E2 /* CoordinateSystem.swift */,
 				676DB15F8AB0CDE3ABC8013B /* CopyConstructable.swift */,
 				94E51857651700E464521E8E /* Curve.swift */,
 				2333C76B6A110FEEC1C62323 /* Dimension.swift */,
@@ -488,7 +488,7 @@
 				69485BBF6305A95649F715D0 /* Coordinate2DM.swift in Sources */,
 				6430B7134345D6852C3CAF90 /* Coordinate3D.swift in Sources */,
 				E8322BA39B7B6A191591BDC3 /* Coordinate3DM.swift in Sources */,
-				2D6686C8B35B5435179DE0CB /* CoordinateReferenceSystem.swift in Sources */,
+				2D6686C8B35B5435179DE0CB /* CoordinateSystem.swift in Sources */,
 				BBFFB31BAE52415C4D204990 /* CopyConstructable.swift in Sources */,
 				7617F12ED1957374172D1240 /* Curve.swift in Sources */,
 				19B8CE8E6A5A044E7C862B0F /* Dimension.swift in Sources */,

--- a/Sources/GeoFeatures/Collection.swift
+++ b/Sources/GeoFeatures/Collection.swift
@@ -29,14 +29,14 @@ public protocol Collection: Swift.Collection, MutableCollection, _DestructorSafe
     /**
         Collections are empty constructable
      */
-    init(precision: Precision, coordinateReferenceSystem: CoordinateReferenceSystem)
+    init(precision: Precision, coordinateSystem: CoordinateSystem)
 
     /**
         Collection can be constructed from any Swift.Collection including Array as
         long as it has an Element type equal Self.Element and the Distance
         is an Int type.
      */
-    init<C: Swift.Collection>(elements: C, precision: Precision, coordinateReferenceSystem: CoordinateReferenceSystem) where C.Iterator.Element == Element
+    init<C: Swift.Collection>(elements: C, precision: Precision, coordinateSystem: CoordinateSystem) where C.Iterator.Element == Element
 
     /**
         - Returns: The number of Geometry objects.

--- a/Sources/GeoFeatures/CoordinateCollection.swift.gyb
+++ b/Sources/GeoFeatures/CoordinateCollection.swift.gyb
@@ -36,19 +36,19 @@ import Swift
 public struct ${Self}<CoordinateType: Coordinate & CopyConstructable> {
 
     public let precision: Precision
-    public let coordinateReferenceSystem: CoordinateReferenceSystem
+    public let coordinateSystem: CoordinateSystem
 
-    public init(coordinateReferenceSystem: CoordinateReferenceSystem) {
-        self.init(precision: defaultPrecision, coordinateReferenceSystem: coordinateReferenceSystem)
+    public init(coordinateSystem: CoordinateSystem) {
+        self.init(precision: defaultPrecision, coordinateSystem: coordinateSystem)
     }
 
     public init(precision: Precision) {
-        self.init(precision: precision, coordinateReferenceSystem: defaultCoordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: defaultCoordinateSystem)
     }
 
-    public init(precision: Precision, coordinateReferenceSystem: CoordinateReferenceSystem) {
+    public init(precision: Precision, coordinateSystem: CoordinateSystem) {
         self.precision = precision
-        self.coordinateReferenceSystem = coordinateReferenceSystem
+        self.coordinateSystem = coordinateSystem
 
         buffer = CollectionBuffer<CoordinateType>.create(minimumCapacity: 8) { newBuffer in CollectionBufferHeader(capacity: newBuffer.capacity, count: 0) } as! CollectionBuffer<CoordinateType> // swiftlint:disable:this force_cast
     }
@@ -59,14 +59,14 @@ public struct ${Self}<CoordinateType: Coordinate & CopyConstructable> {
         - parameters:
             - other: The ${Self} of the same type that you want to construct a new ${Self} from.
             - precision: The `Precision` model this polygon should use in calculations on it's coordinates.
-            - coordinateReferenceSystem: The 'CoordinateReferenceSystem` this polygon should use in calculations on it's coordinates.
+            - coordinateSystem: The 'CoordinateSystem` this polygon should use in calculations on it's coordinates.
 
-        - seealso: `CoordinateReferenceSystem`
+        - seealso: `CoordinateSystem`
         - seealso: `Precision`
      */
-    public init(other: ${Self}<CoordinateType>, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) {
+    public init(other: ${Self}<CoordinateType>, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
         other.buffer.withUnsafeMutablePointers { (header, elements) -> Void in
 
@@ -106,7 +106,7 @@ extension ${Self}: Collection {
         ${Self}s are empty constructable
      */
     public init() {
-        self.init(precision: defaultPrecision, coordinateReferenceSystem: defaultCoordinateReferenceSystem)
+        self.init(precision: defaultPrecision, coordinateSystem: defaultCoordinateSystem)
     }
 
     /**
@@ -114,9 +114,9 @@ extension ${Self}: Collection {
         long as it has an Element type equal the Coordinate type specified in Element
         and the Distance is an Int type.
      */
-    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) where C.Iterator.Element == CoordinateType {
+    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) where C.Iterator.Element == CoordinateType {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
         self.reserveCapacity(numericCast(elements.count))
 
@@ -249,9 +249,9 @@ extension ${Self} where CoordinateType: TupleConvertible & CopyConstructable {
 
         - seealso: TupleConvertible.
      */
-    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) where C.Iterator.Element == CoordinateType.TupleType {
+    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) where C.Iterator.Element == CoordinateType.TupleType {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
         self.reserveCapacity(numericCast(elements.count))
 

--- a/Sources/GeoFeatures/CoordinateSystem.swift
+++ b/Sources/GeoFeatures/CoordinateSystem.swift
@@ -1,5 +1,5 @@
 /*
- *   CoordinateReferenceSystem.swift
+ *   CoordinateSystem.swift
  *
  *   Copyright 2016 Tony Stone
  *
@@ -24,9 +24,9 @@ import Swift
 
  These are used by the algorythms when they are applyed to the types
 */
-public protocol CoordinateReferenceSystem {}
+public protocol CoordinateSystem {}
 
-public struct Cartesian: CoordinateReferenceSystem {
+public struct Cartesian: CoordinateSystem {
     public init() {}
 }
 
@@ -35,18 +35,18 @@ extension Cartesian: Equatable, Hashable {
 }
 
 @available(*, unavailable, message: "currently not supported")
-public struct Ellipsoidal: CoordinateReferenceSystem {}
+public struct Ellipsoidal: CoordinateSystem {}
 
 @available(*, unavailable, message: "currently not supported")
-public struct Spherical: CoordinateReferenceSystem {}
+public struct Spherical: CoordinateSystem {}
 
 @available(*, unavailable, message: "currently not supported")
-public struct Vertical: CoordinateReferenceSystem {}
+public struct Vertical: CoordinateSystem {}
 
 @available(*, unavailable, message: "currently not supported")
-public struct Polar: CoordinateReferenceSystem {}
+public struct Polar: CoordinateSystem {}
 
-public func == <T1: CoordinateReferenceSystem & Hashable, T2: CoordinateReferenceSystem & Hashable>(lhs: T1, rhs: T2) -> Bool {
+public func == <T1: CoordinateSystem & Hashable, T2: CoordinateSystem & Hashable>(lhs: T1, rhs: T2) -> Bool {
     if type(of: lhs) == type(of: rhs) {
         return lhs.hashValue == rhs.hashValue
     }

--- a/Sources/GeoFeatures/Curve.swift
+++ b/Sources/GeoFeatures/Curve.swift
@@ -28,7 +28,7 @@ public protocol Curve {
     func isClosed() -> Bool
 
     /**
-        The length of this Curve calculated using its associated CoordinateReferenceSystem.
+        The length of this Curve calculated using its associated CoordinateSystem.
      */
 
     func length() -> Double

--- a/Sources/GeoFeatures/GeoJSONReader.swift
+++ b/Sources/GeoFeatures/GeoJSONReader.swift
@@ -40,7 +40,7 @@ public class GeoJSONReader<CoordinateType: Coordinate & CopyConstructable & _Arr
 
     fileprivate let expectedStringEncoding = String.Encoding.utf8
 
-    fileprivate let crs: CoordinateReferenceSystem
+    fileprivate let cs: CoordinateSystem
     fileprivate let precision: Precision
 
     ///
@@ -48,13 +48,13 @@ public class GeoJSONReader<CoordinateType: Coordinate & CopyConstructable & _Arr
     ///
     /// - Parameters:
     ///     - precision: The `Precision` model that should used for all coordinates.
-    ///     - coordinateReferenceSystem: The 'CoordinateReferenceSystem` the result Geometries should use in calculations on their coordinates.
+    ///     - coordinateSystem: The 'CoordinateSystem` the result Geometries should use in calculations on their coordinates.
     ///
     /// - SeeAlso: `Precision`
-    /// - SeeAlso: `CoordinateReferenceSystem`
+    /// - SeeAlso: `CoordinateSystem`
     ///
-    public init(precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) {
-        self.crs = coordinateReferenceSystem
+    public init(precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) {
+        self.cs = coordinateSystem
         self.precision = precision
     }
 
@@ -149,7 +149,7 @@ public class GeoJSONReader<CoordinateType: Coordinate & CopyConstructable & _Arr
     // Parse coordinates into a Point
     private func point(coordinates: [Double]) throws -> Point<CoordinateType> {
 
-        return Point<CoordinateType>(coordinate: try self.coordinate(array: coordinates), precision: self.precision, coordinateReferenceSystem: self.crs)
+        return Point<CoordinateType>(coordinate: try self.coordinate(array: coordinates), precision: self.precision, coordinateSystem: self.cs)
     }
 
     // Parse a LineString type
@@ -157,7 +157,7 @@ public class GeoJSONReader<CoordinateType: Coordinate & CopyConstructable & _Arr
 
         let coordinates = try Coordinates<[[Double]]>.coordinates(json: jsonObject)
 
-        return LineString<CoordinateType>(elements: try self.coordinates(jsonArray: coordinates), precision: self.precision, coordinateReferenceSystem: self.crs)
+        return LineString<CoordinateType>(elements: try self.coordinates(jsonArray: coordinates), precision: self.precision, coordinateSystem: self.cs)
     }
 
     // Parse coordinates into a LineString
@@ -169,7 +169,7 @@ public class GeoJSONReader<CoordinateType: Coordinate & CopyConstructable & _Arr
             elements.append(try self.coordinate(array: elementCoordinates))
         }
 
-        return LineString<CoordinateType>(elements: try self.coordinates(jsonArray: coordinates), precision: self.precision, coordinateReferenceSystem: self.crs)
+        return LineString<CoordinateType>(elements: try self.coordinates(jsonArray: coordinates), precision: self.precision, coordinateSystem: self.cs)
     }
 
     // Parse a Polygon type
@@ -183,7 +183,7 @@ public class GeoJSONReader<CoordinateType: Coordinate & CopyConstructable & _Arr
     // Parse coordinates into a Polygon
     private func polygon(coordinates: [[[Double]]]) throws -> Polygon<CoordinateType> {
 
-        var outerRing:  LinearRing<CoordinateType> = LinearRing<CoordinateType>(precision: self.precision, coordinateReferenceSystem: self.crs)
+        var outerRing:  LinearRing<CoordinateType> = LinearRing<CoordinateType>(precision: self.precision, coordinateSystem: self.cs)
         var innerRings: [LinearRing<CoordinateType>] = []
 
         if coordinates.count > 0 {
@@ -192,9 +192,9 @@ public class GeoJSONReader<CoordinateType: Coordinate & CopyConstructable & _Arr
 
         // Get the inner rings
         for i in stride(from: 1, to: coordinates.count, by: 1) {
-            innerRings.append(LinearRing<CoordinateType>(elements: try self.coordinates(jsonArray: coordinates[i]), precision: self.precision, coordinateReferenceSystem: self.crs))
+            innerRings.append(LinearRing<CoordinateType>(elements: try self.coordinates(jsonArray: coordinates[i]), precision: self.precision, coordinateSystem: self.cs))
         }
-        return Polygon<CoordinateType>(outerRing: outerRing, innerRings: innerRings, precision: self.precision, coordinateReferenceSystem: self.crs)
+        return Polygon<CoordinateType>(outerRing: outerRing, innerRings: innerRings, precision: self.precision, coordinateSystem: self.cs)
     }
 
     // Parse a MultiPoint type
@@ -214,7 +214,7 @@ public class GeoJSONReader<CoordinateType: Coordinate & CopyConstructable & _Arr
             elements.append(try self.point(coordinates: elementCoordinates))
         }
 
-        return MultiPoint<CoordinateType>(elements: elements, precision: self.precision, coordinateReferenceSystem: self.crs)
+        return MultiPoint<CoordinateType>(elements: elements, precision: self.precision, coordinateSystem: self.cs)
     }
 
     // Parse a MultiLineString type
@@ -234,7 +234,7 @@ public class GeoJSONReader<CoordinateType: Coordinate & CopyConstructable & _Arr
             elements.append(try self.lineString(coordinates: elementCoordinates))
         }
 
-        return MultiLineString<CoordinateType>(elements: elements, precision: self.precision, coordinateReferenceSystem: self.crs)
+        return MultiLineString<CoordinateType>(elements: elements, precision: self.precision, coordinateSystem: self.cs)
     }
 
     // Parse a MultiPolygon type
@@ -254,7 +254,7 @@ public class GeoJSONReader<CoordinateType: Coordinate & CopyConstructable & _Arr
             elements.append(try self.polygon(coordinates: elementCoordinates))
         }
 
-        return MultiPolygon<CoordinateType>(elements: elements, precision: self.precision, coordinateReferenceSystem: self.crs)
+        return MultiPolygon<CoordinateType>(elements: elements, precision: self.precision, coordinateSystem: self.cs)
     }
 
     // Parse a GeometryCollection type
@@ -272,7 +272,7 @@ public class GeoJSONReader<CoordinateType: Coordinate & CopyConstructable & _Arr
         for object in geometries {
             elements.append(try self.read(jsonObject: object))
         }
-        return GeometryCollection(elements: elements, precision: self.precision, coordinateReferenceSystem: self.crs)
+        return GeometryCollection(elements: elements, precision: self.precision, coordinateSystem: self.cs)
     }
 
     private func coordinates(jsonArray: [[Double]]) throws -> [CoordinateType] {

--- a/Sources/GeoFeatures/Geometry.swift
+++ b/Sources/GeoFeatures/Geometry.swift
@@ -25,9 +25,9 @@ Default Precision for all class
 public let defaultPrecision = FloatingPrecision()
 
 /**
-Default CoordinateReferenceSystem
+Default CoordinateSystem
 */
-public let defaultCoordinateReferenceSystem = Cartesian()
+public let defaultCoordinateSystem = Cartesian()
 
 /**
  Geometry
@@ -45,7 +45,7 @@ public protocol Geometry {
     /**
         The Coordinate Reference System used in algorithms applied to this GeoemetryType
     */
-    var coordinateReferenceSystem: CoordinateReferenceSystem { get }
+    var coordinateSystem: CoordinateSystem { get }
 
     /**
         The inherent dimension of this Geoemetry.

--- a/Sources/GeoFeatures/GeometryCollection+Geometry.swift
+++ b/Sources/GeoFeatures/GeometryCollection+Geometry.swift
@@ -54,7 +54,7 @@ extension GeometryCollection: Geometry {
     public
     func boundary() -> Geometry {
         // Return an empty GeometryCollection
-        return GeometryCollection(precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem)
+        return GeometryCollection(precision: self.precision, coordinateSystem: self.coordinateSystem)
     }
 
     public func equals(_ other: Geometry) -> Bool {

--- a/Sources/GeoFeatures/GeometryCollection.swift
+++ b/Sources/GeoFeatures/GeometryCollection.swift
@@ -40,19 +40,19 @@ public struct GeometryCollection {
     public typealias Element = Geometry
 
     public let precision: Precision
-    public let coordinateReferenceSystem: CoordinateReferenceSystem
+    public let coordinateSystem: CoordinateSystem
 
-    public init(coordinateReferenceSystem: CoordinateReferenceSystem) {
-        self.init(precision: defaultPrecision, coordinateReferenceSystem: coordinateReferenceSystem)
+    public init(coordinateSystem: CoordinateSystem) {
+        self.init(precision: defaultPrecision, coordinateSystem: coordinateSystem)
     }
 
     public init(precision: Precision) {
-        self.init(precision: precision, coordinateReferenceSystem: defaultCoordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: defaultCoordinateSystem)
     }
 
-    public init(precision: Precision, coordinateReferenceSystem: CoordinateReferenceSystem) {
+    public init(precision: Precision, coordinateSystem: CoordinateSystem) {
         self.precision = precision
-        self.coordinateReferenceSystem = coordinateReferenceSystem
+        self.coordinateSystem = coordinateSystem
 
         buffer = CollectionBuffer<Element>.create(minimumCapacity: 8) { newBuffer in CollectionBufferHeader(capacity: newBuffer.capacity, count: 0) } as! CollectionBuffer<Element> // swiftlint:disable:this force_cast
     }
@@ -87,7 +87,7 @@ extension GeometryCollection: Collection {
         GeometryCollections are empty constructable
      */
     public init() {
-        self.init(precision: defaultPrecision, coordinateReferenceSystem: defaultCoordinateReferenceSystem)
+        self.init(precision: defaultPrecision, coordinateSystem: defaultCoordinateSystem)
     }
 
     /**
@@ -95,9 +95,9 @@ extension GeometryCollection: Collection {
         long as it has an Element type equal the Geometry Element and the Distance
         is an Int type.
      */
-    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) where C.Iterator.Element == Element {
+    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) where C.Iterator.Element == Element {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
         self.reserveCapacity(numericCast(elements.count))
 

--- a/Sources/GeoFeatures/GeometryCollection.swift.gyb
+++ b/Sources/GeoFeatures/GeometryCollection.swift.gyb
@@ -46,19 +46,19 @@ public struct ${Self} {
 %end
 
     public let precision: Precision
-    public let coordinateReferenceSystem: CoordinateReferenceSystem
+    public let coordinateSystem: CoordinateSystem
 
-    public init(coordinateReferenceSystem: CoordinateReferenceSystem) {
-        self.init(precision: defaultPrecision, coordinateReferenceSystem: coordinateReferenceSystem)
+    public init(coordinateSystem: CoordinateSystem) {
+        self.init(precision: defaultPrecision, coordinateSystem: coordinateSystem)
     }
 
     public init(precision: Precision) {
-        self.init(precision: precision, coordinateReferenceSystem: defaultCoordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: defaultCoordinateSystem)
     }
 
-    public init(precision: Precision, coordinateReferenceSystem: CoordinateReferenceSystem) {
+    public init(precision: Precision, coordinateSystem: CoordinateSystem) {
         self.precision = precision
-        self.coordinateReferenceSystem = coordinateReferenceSystem
+        self.coordinateSystem = coordinateSystem
 
         buffer = CollectionBuffer<Element>.create(minimumCapacity: 8) { newBuffer in CollectionBufferHeader(capacity: newBuffer.capacity, count: 0) } as! CollectionBuffer<Element> // swiftlint:disable:this force_cast
     }
@@ -93,7 +93,7 @@ extension ${Self}: Collection {
         ${Self}s are empty constructable
      */
     public init() {
-        self.init(precision: defaultPrecision, coordinateReferenceSystem: defaultCoordinateReferenceSystem)
+        self.init(precision: defaultPrecision, coordinateSystem: defaultCoordinateSystem)
     }
 
     /**
@@ -101,9 +101,9 @@ extension ${Self}: Collection {
         long as it has an Element type equal the Geometry Element and the Distance
         is an Int type.
      */
-    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) where C.Iterator.Element == Element {
+    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) where C.Iterator.Element == Element {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
         self.reserveCapacity(numericCast(elements.count))
 
@@ -155,7 +155,7 @@ extension ${Self}: Collection {
 
 %if CoordinateSpecialized == 'true':
         /// We create a new instance of the Element so we can adjust the precision and Coordinate reference system of the Element before adding.
-        buffer.append(Element(other: newElement, precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem))
+        buffer.append(Element(other: newElement, precision: self.precision, coordinateSystem: self.coordinateSystem))
 %else:
         buffer.append(newElement)
 %end
@@ -187,7 +187,7 @@ extension ${Self}: Collection {
 
 %if CoordinateSpecialized == 'true':
         /// We create a new instance of the Element so we can adjust the precision and Coordinate reference system of the Element before adding.
-        buffer.insert(Element(other: newElement, precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem), at: index)
+        buffer.insert(Element(other: newElement, precision: self.precision, coordinateSystem: self.coordinateSystem), at: index)
 %else:
         buffer.insert(newElement, at: index)
 %end
@@ -268,7 +268,7 @@ extension ${Self} {
 
 %if CoordinateSpecialized == 'true':
             /// We create a new instance of the Element so we can adjust the precision and Coordinate reference system of the Element before adding.
-            buffer.update(Element(other: newValue, precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem), at: index)
+            buffer.update(Element(other: newValue, precision: self.precision, coordinateSystem: self.coordinateSystem), at: index)
 %else:
             buffer.update(newValue, at: index)
 %end

--- a/Sources/GeoFeatures/LineString+Curve.swift
+++ b/Sources/GeoFeatures/LineString+Curve.swift
@@ -42,7 +42,7 @@ extension LineString: Curve {
     }
 
     /**
-     The length of this LinearType calculated using its associated CoordinateReferenceSystem.
+     The length of this LinearType calculated using its associated CoordinateSystem.
      */
 
     public

--- a/Sources/GeoFeatures/LineString+Geometry.swift
+++ b/Sources/GeoFeatures/LineString+Geometry.swift
@@ -40,13 +40,13 @@ extension LineString: Geometry {
 
         return self.buffer.withUnsafeMutablePointers { (header, elements) -> Geometry in
 
-            var multiPoint = MultiPoint<CoordinateType>(precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem)
+            var multiPoint = MultiPoint<CoordinateType>(precision: self.precision, coordinateSystem: self.coordinateSystem)
 
             if !self.isClosed() && header.pointee.count >= 2 {
 
                 // Note: direct subscripts protected by self.count >= 2 above.
-                multiPoint.append(Point<CoordinateType>(coordinate: elements[0], precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem))
-                multiPoint.append(Point<CoordinateType>(coordinate: elements[header.pointee.count - 1], precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem))
+                multiPoint.append(Point<CoordinateType>(coordinate: elements[0], precision: self.precision, coordinateSystem: self.coordinateSystem))
+                multiPoint.append(Point<CoordinateType>(coordinate: elements[header.pointee.count - 1], precision: self.precision, coordinateSystem: self.coordinateSystem))
 
             }
             return multiPoint

--- a/Sources/GeoFeatures/LineString.swift
+++ b/Sources/GeoFeatures/LineString.swift
@@ -36,19 +36,19 @@ import Swift
 public struct LineString<CoordinateType: Coordinate & CopyConstructable> {
 
     public let precision: Precision
-    public let coordinateReferenceSystem: CoordinateReferenceSystem
+    public let coordinateSystem: CoordinateSystem
 
-    public init(coordinateReferenceSystem: CoordinateReferenceSystem) {
-        self.init(precision: defaultPrecision, coordinateReferenceSystem: coordinateReferenceSystem)
+    public init(coordinateSystem: CoordinateSystem) {
+        self.init(precision: defaultPrecision, coordinateSystem: coordinateSystem)
     }
 
     public init(precision: Precision) {
-        self.init(precision: precision, coordinateReferenceSystem: defaultCoordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: defaultCoordinateSystem)
     }
 
-    public init(precision: Precision, coordinateReferenceSystem: CoordinateReferenceSystem) {
+    public init(precision: Precision, coordinateSystem: CoordinateSystem) {
         self.precision = precision
-        self.coordinateReferenceSystem = coordinateReferenceSystem
+        self.coordinateSystem = coordinateSystem
 
         buffer = CollectionBuffer<CoordinateType>.create(minimumCapacity: 8) { newBuffer in CollectionBufferHeader(capacity: newBuffer.capacity, count: 0) } as! CollectionBuffer<CoordinateType> // swiftlint:disable:this force_cast
     }
@@ -59,14 +59,14 @@ public struct LineString<CoordinateType: Coordinate & CopyConstructable> {
         - parameters:
             - other: The LineString of the same type that you want to construct a new LineString from.
             - precision: The `Precision` model this polygon should use in calculations on it's coordinates.
-            - coordinateReferenceSystem: The 'CoordinateReferenceSystem` this polygon should use in calculations on it's coordinates.
+            - coordinateSystem: The 'CoordinateSystem` this polygon should use in calculations on it's coordinates.
 
-        - seealso: `CoordinateReferenceSystem`
+        - seealso: `CoordinateSystem`
         - seealso: `Precision`
      */
-    public init(other: LineString<CoordinateType>, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) {
+    public init(other: LineString<CoordinateType>, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
         other.buffer.withUnsafeMutablePointers { (header, elements) -> Void in
 
@@ -106,7 +106,7 @@ extension LineString: Collection {
         LineStrings are empty constructable
      */
     public init() {
-        self.init(precision: defaultPrecision, coordinateReferenceSystem: defaultCoordinateReferenceSystem)
+        self.init(precision: defaultPrecision, coordinateSystem: defaultCoordinateSystem)
     }
 
     /**
@@ -114,9 +114,9 @@ extension LineString: Collection {
         long as it has an Element type equal the Coordinate type specified in Element
         and the Distance is an Int type.
      */
-    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) where C.Iterator.Element == CoordinateType {
+    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) where C.Iterator.Element == CoordinateType {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
         self.reserveCapacity(numericCast(elements.count))
 
@@ -249,9 +249,9 @@ extension LineString where CoordinateType: TupleConvertible & CopyConstructable 
 
         - seealso: TupleConvertible.
      */
-    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) where C.Iterator.Element == CoordinateType.TupleType {
+    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) where C.Iterator.Element == CoordinateType.TupleType {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
         self.reserveCapacity(numericCast(elements.count))
 

--- a/Sources/GeoFeatures/LinearRing+Curve.swift
+++ b/Sources/GeoFeatures/LinearRing+Curve.swift
@@ -42,7 +42,7 @@ extension LinearRing: Curve {
     }
 
     /**
-     The length of this LinearType calculated using its associated CoordinateReferenceSystem.
+     The length of this LinearType calculated using its associated CoordinateSystem.
      */
 
     public

--- a/Sources/GeoFeatures/LinearRing+Geometry.swift
+++ b/Sources/GeoFeatures/LinearRing+Geometry.swift
@@ -40,13 +40,13 @@ extension LinearRing: Geometry {
 
         return self.buffer.withUnsafeMutablePointers { (header, elements) -> Geometry in
 
-            var multiPoint = MultiPoint<CoordinateType>(precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem)
+            var multiPoint = MultiPoint<CoordinateType>(precision: self.precision, coordinateSystem: self.coordinateSystem)
 
             if !self.isClosed() && header.pointee.count >= 2 {
 
                 // Note: direct subscripts protected by self.count >= 2 above.
-                multiPoint.append(Point<CoordinateType>(coordinate: elements[0], precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem))
-                multiPoint.append(Point<CoordinateType>(coordinate: elements[header.pointee.count - 1], precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem))
+                multiPoint.append(Point<CoordinateType>(coordinate: elements[0], precision: self.precision, coordinateSystem: self.coordinateSystem))
+                multiPoint.append(Point<CoordinateType>(coordinate: elements[header.pointee.count - 1], precision: self.precision, coordinateSystem: self.coordinateSystem))
 
             }
             return multiPoint

--- a/Sources/GeoFeatures/LinearRing.swift
+++ b/Sources/GeoFeatures/LinearRing.swift
@@ -36,19 +36,19 @@ import Swift
 public struct LinearRing<CoordinateType: Coordinate & CopyConstructable> {
 
     public let precision: Precision
-    public let coordinateReferenceSystem: CoordinateReferenceSystem
+    public let coordinateSystem: CoordinateSystem
 
-    public init(coordinateReferenceSystem: CoordinateReferenceSystem) {
-        self.init(precision: defaultPrecision, coordinateReferenceSystem: coordinateReferenceSystem)
+    public init(coordinateSystem: CoordinateSystem) {
+        self.init(precision: defaultPrecision, coordinateSystem: coordinateSystem)
     }
 
     public init(precision: Precision) {
-        self.init(precision: precision, coordinateReferenceSystem: defaultCoordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: defaultCoordinateSystem)
     }
 
-    public init(precision: Precision, coordinateReferenceSystem: CoordinateReferenceSystem) {
+    public init(precision: Precision, coordinateSystem: CoordinateSystem) {
         self.precision = precision
-        self.coordinateReferenceSystem = coordinateReferenceSystem
+        self.coordinateSystem = coordinateSystem
 
         buffer = CollectionBuffer<CoordinateType>.create(minimumCapacity: 8) { newBuffer in CollectionBufferHeader(capacity: newBuffer.capacity, count: 0) } as! CollectionBuffer<CoordinateType> // swiftlint:disable:this force_cast
     }
@@ -59,14 +59,14 @@ public struct LinearRing<CoordinateType: Coordinate & CopyConstructable> {
         - parameters:
             - other: The LinearRing of the same type that you want to construct a new LinearRing from.
             - precision: The `Precision` model this polygon should use in calculations on it's coordinates.
-            - coordinateReferenceSystem: The 'CoordinateReferenceSystem` this polygon should use in calculations on it's coordinates.
+            - coordinateSystem: The 'CoordinateSystem` this polygon should use in calculations on it's coordinates.
 
-        - seealso: `CoordinateReferenceSystem`
+        - seealso: `CoordinateSystem`
         - seealso: `Precision`
      */
-    public init(other: LinearRing<CoordinateType>, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) {
+    public init(other: LinearRing<CoordinateType>, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
         other.buffer.withUnsafeMutablePointers { (header, elements) -> Void in
 
@@ -106,7 +106,7 @@ extension LinearRing: Collection {
         LinearRings are empty constructable
      */
     public init() {
-        self.init(precision: defaultPrecision, coordinateReferenceSystem: defaultCoordinateReferenceSystem)
+        self.init(precision: defaultPrecision, coordinateSystem: defaultCoordinateSystem)
     }
 
     /**
@@ -114,9 +114,9 @@ extension LinearRing: Collection {
         long as it has an Element type equal the Coordinate type specified in Element
         and the Distance is an Int type.
      */
-    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) where C.Iterator.Element == CoordinateType {
+    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) where C.Iterator.Element == CoordinateType {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
         self.reserveCapacity(numericCast(elements.count))
 
@@ -249,9 +249,9 @@ extension LinearRing where CoordinateType: TupleConvertible & CopyConstructable 
 
         - seealso: TupleConvertible.
      */
-    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) where C.Iterator.Element == CoordinateType.TupleType {
+    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) where C.Iterator.Element == CoordinateType.TupleType {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
         self.reserveCapacity(numericCast(elements.count))
 

--- a/Sources/GeoFeatures/MultiLineString+Geometry.swift
+++ b/Sources/GeoFeatures/MultiLineString+Geometry.swift
@@ -74,11 +74,11 @@ extension MultiLineString: Geometry {
                 }
             }
 
-            var multiPoint = MultiPoint<CoordinateType>(precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem)
+            var multiPoint = MultiPoint<CoordinateType>(precision: self.precision, coordinateSystem: self.coordinateSystem)
 
             for (coordinate, count) in endCoordinates {
                 if count % 2 == 1 {
-                    multiPoint.append(Point(coordinate: coordinate, precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem))
+                    multiPoint.append(Point(coordinate: coordinate, precision: self.precision, coordinateSystem: self.coordinateSystem))
                 }
             }
             return multiPoint

--- a/Sources/GeoFeatures/MultiLineString.swift
+++ b/Sources/GeoFeatures/MultiLineString.swift
@@ -40,19 +40,19 @@ public struct MultiLineString<CoordinateType: Coordinate & CopyConstructable> {
     public typealias Element = LineString<CoordinateType>
 
     public let precision: Precision
-    public let coordinateReferenceSystem: CoordinateReferenceSystem
+    public let coordinateSystem: CoordinateSystem
 
-    public init(coordinateReferenceSystem: CoordinateReferenceSystem) {
-        self.init(precision: defaultPrecision, coordinateReferenceSystem: coordinateReferenceSystem)
+    public init(coordinateSystem: CoordinateSystem) {
+        self.init(precision: defaultPrecision, coordinateSystem: coordinateSystem)
     }
 
     public init(precision: Precision) {
-        self.init(precision: precision, coordinateReferenceSystem: defaultCoordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: defaultCoordinateSystem)
     }
 
-    public init(precision: Precision, coordinateReferenceSystem: CoordinateReferenceSystem) {
+    public init(precision: Precision, coordinateSystem: CoordinateSystem) {
         self.precision = precision
-        self.coordinateReferenceSystem = coordinateReferenceSystem
+        self.coordinateSystem = coordinateSystem
 
         buffer = CollectionBuffer<Element>.create(minimumCapacity: 8) { newBuffer in CollectionBufferHeader(capacity: newBuffer.capacity, count: 0) } as! CollectionBuffer<Element> // swiftlint:disable:this force_cast
     }
@@ -87,7 +87,7 @@ extension MultiLineString: Collection {
         MultiLineStrings are empty constructable
      */
     public init() {
-        self.init(precision: defaultPrecision, coordinateReferenceSystem: defaultCoordinateReferenceSystem)
+        self.init(precision: defaultPrecision, coordinateSystem: defaultCoordinateSystem)
     }
 
     /**
@@ -95,9 +95,9 @@ extension MultiLineString: Collection {
         long as it has an Element type equal the Geometry Element and the Distance
         is an Int type.
      */
-    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) where C.Iterator.Element == Element {
+    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) where C.Iterator.Element == Element {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
         self.reserveCapacity(numericCast(elements.count))
 
@@ -148,7 +148,7 @@ extension MultiLineString: Collection {
         _resizeIfNeeded()
 
         /// We create a new instance of the Element so we can adjust the precision and Coordinate reference system of the Element before adding.
-        buffer.append(Element(other: newElement, precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem))
+        buffer.append(Element(other: newElement, precision: self.precision, coordinateSystem: self.coordinateSystem))
     }
 
     /**
@@ -176,7 +176,7 @@ extension MultiLineString: Collection {
         _resizeIfNeeded()
 
         /// We create a new instance of the Element so we can adjust the precision and Coordinate reference system of the Element before adding.
-        buffer.insert(Element(other: newElement, precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem), at: index)
+        buffer.insert(Element(other: newElement, precision: self.precision, coordinateSystem: self.coordinateSystem), at: index)
     }
 
     /**
@@ -253,7 +253,7 @@ extension MultiLineString {
             _ensureUniquelyReferenced()
 
             /// We create a new instance of the Element so we can adjust the precision and Coordinate reference system of the Element before adding.
-            buffer.update(Element(other: newValue, precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem), at: index)
+            buffer.update(Element(other: newValue, precision: self.precision, coordinateSystem: self.coordinateSystem), at: index)
         }
     }
 }

--- a/Sources/GeoFeatures/MultiPoint+Geometry.swift
+++ b/Sources/GeoFeatures/MultiPoint+Geometry.swift
@@ -37,7 +37,7 @@ extension MultiPoint: Geometry {
 
     public
     func boundary() -> Geometry {
-        return MultiPoint<CoordinateType>(precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem)
+        return MultiPoint<CoordinateType>(precision: self.precision, coordinateSystem: self.coordinateSystem)
     }
 
     public

--- a/Sources/GeoFeatures/MultiPoint.swift
+++ b/Sources/GeoFeatures/MultiPoint.swift
@@ -40,19 +40,19 @@ public struct MultiPoint<CoordinateType: Coordinate & CopyConstructable> {
     public typealias Element = Point<CoordinateType>
 
     public let precision: Precision
-    public let coordinateReferenceSystem: CoordinateReferenceSystem
+    public let coordinateSystem: CoordinateSystem
 
-    public init(coordinateReferenceSystem: CoordinateReferenceSystem) {
-        self.init(precision: defaultPrecision, coordinateReferenceSystem: coordinateReferenceSystem)
+    public init(coordinateSystem: CoordinateSystem) {
+        self.init(precision: defaultPrecision, coordinateSystem: coordinateSystem)
     }
 
     public init(precision: Precision) {
-        self.init(precision: precision, coordinateReferenceSystem: defaultCoordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: defaultCoordinateSystem)
     }
 
-    public init(precision: Precision, coordinateReferenceSystem: CoordinateReferenceSystem) {
+    public init(precision: Precision, coordinateSystem: CoordinateSystem) {
         self.precision = precision
-        self.coordinateReferenceSystem = coordinateReferenceSystem
+        self.coordinateSystem = coordinateSystem
 
         buffer = CollectionBuffer<Element>.create(minimumCapacity: 8) { newBuffer in CollectionBufferHeader(capacity: newBuffer.capacity, count: 0) } as! CollectionBuffer<Element> // swiftlint:disable:this force_cast
     }
@@ -87,7 +87,7 @@ extension MultiPoint: Collection {
         MultiPoints are empty constructable
      */
     public init() {
-        self.init(precision: defaultPrecision, coordinateReferenceSystem: defaultCoordinateReferenceSystem)
+        self.init(precision: defaultPrecision, coordinateSystem: defaultCoordinateSystem)
     }
 
     /**
@@ -95,9 +95,9 @@ extension MultiPoint: Collection {
         long as it has an Element type equal the Geometry Element and the Distance
         is an Int type.
      */
-    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) where C.Iterator.Element == Element {
+    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) where C.Iterator.Element == Element {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
         self.reserveCapacity(numericCast(elements.count))
 
@@ -148,7 +148,7 @@ extension MultiPoint: Collection {
         _resizeIfNeeded()
 
         /// We create a new instance of the Element so we can adjust the precision and Coordinate reference system of the Element before adding.
-        buffer.append(Element(other: newElement, precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem))
+        buffer.append(Element(other: newElement, precision: self.precision, coordinateSystem: self.coordinateSystem))
     }
 
     /**
@@ -176,7 +176,7 @@ extension MultiPoint: Collection {
         _resizeIfNeeded()
 
         /// We create a new instance of the Element so we can adjust the precision and Coordinate reference system of the Element before adding.
-        buffer.insert(Element(other: newElement, precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem), at: index)
+        buffer.insert(Element(other: newElement, precision: self.precision, coordinateSystem: self.coordinateSystem), at: index)
     }
 
     /**
@@ -253,7 +253,7 @@ extension MultiPoint {
             _ensureUniquelyReferenced()
 
             /// We create a new instance of the Element so we can adjust the precision and Coordinate reference system of the Element before adding.
-            buffer.update(Element(other: newValue, precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem), at: index)
+            buffer.update(Element(other: newValue, precision: self.precision, coordinateSystem: self.coordinateSystem), at: index)
         }
     }
 }

--- a/Sources/GeoFeatures/MultiPolygon+Geometry.swift
+++ b/Sources/GeoFeatures/MultiPolygon+Geometry.swift
@@ -38,7 +38,7 @@ extension MultiPolygon: Geometry {
     public
     func boundary() -> Geometry {
         return self.buffer.withUnsafeMutablePointers({ (header, elements) -> Geometry in
-            var multiLineString = MultiLineString<CoordinateType>(precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem)
+            var multiLineString = MultiLineString<CoordinateType>(precision: self.precision, coordinateSystem: self.coordinateSystem)
 
             for i in 0..<header.pointee.count {
 

--- a/Sources/GeoFeatures/MultiPolygon.swift
+++ b/Sources/GeoFeatures/MultiPolygon.swift
@@ -40,19 +40,19 @@ public struct MultiPolygon<CoordinateType: Coordinate & CopyConstructable> {
     public typealias Element = Polygon<CoordinateType>
 
     public let precision: Precision
-    public let coordinateReferenceSystem: CoordinateReferenceSystem
+    public let coordinateSystem: CoordinateSystem
 
-    public init(coordinateReferenceSystem: CoordinateReferenceSystem) {
-        self.init(precision: defaultPrecision, coordinateReferenceSystem: coordinateReferenceSystem)
+    public init(coordinateSystem: CoordinateSystem) {
+        self.init(precision: defaultPrecision, coordinateSystem: coordinateSystem)
     }
 
     public init(precision: Precision) {
-        self.init(precision: precision, coordinateReferenceSystem: defaultCoordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: defaultCoordinateSystem)
     }
 
-    public init(precision: Precision, coordinateReferenceSystem: CoordinateReferenceSystem) {
+    public init(precision: Precision, coordinateSystem: CoordinateSystem) {
         self.precision = precision
-        self.coordinateReferenceSystem = coordinateReferenceSystem
+        self.coordinateSystem = coordinateSystem
 
         buffer = CollectionBuffer<Element>.create(minimumCapacity: 8) { newBuffer in CollectionBufferHeader(capacity: newBuffer.capacity, count: 0) } as! CollectionBuffer<Element> // swiftlint:disable:this force_cast
     }
@@ -87,7 +87,7 @@ extension MultiPolygon: Collection {
         MultiPolygons are empty constructable
      */
     public init() {
-        self.init(precision: defaultPrecision, coordinateReferenceSystem: defaultCoordinateReferenceSystem)
+        self.init(precision: defaultPrecision, coordinateSystem: defaultCoordinateSystem)
     }
 
     /**
@@ -95,9 +95,9 @@ extension MultiPolygon: Collection {
         long as it has an Element type equal the Geometry Element and the Distance
         is an Int type.
      */
-    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) where C.Iterator.Element == Element {
+    public init<C: Swift.Collection>(elements: C, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) where C.Iterator.Element == Element {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
         self.reserveCapacity(numericCast(elements.count))
 
@@ -148,7 +148,7 @@ extension MultiPolygon: Collection {
         _resizeIfNeeded()
 
         /// We create a new instance of the Element so we can adjust the precision and Coordinate reference system of the Element before adding.
-        buffer.append(Element(other: newElement, precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem))
+        buffer.append(Element(other: newElement, precision: self.precision, coordinateSystem: self.coordinateSystem))
     }
 
     /**
@@ -176,7 +176,7 @@ extension MultiPolygon: Collection {
         _resizeIfNeeded()
 
         /// We create a new instance of the Element so we can adjust the precision and Coordinate reference system of the Element before adding.
-        buffer.insert(Element(other: newElement, precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem), at: index)
+        buffer.insert(Element(other: newElement, precision: self.precision, coordinateSystem: self.coordinateSystem), at: index)
     }
 
     /**
@@ -253,7 +253,7 @@ extension MultiPolygon {
             _ensureUniquelyReferenced()
 
             /// We create a new instance of the Element so we can adjust the precision and Coordinate reference system of the Element before adding.
-            buffer.update(Element(other: newValue, precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem), at: index)
+            buffer.update(Element(other: newValue, precision: self.precision, coordinateSystem: self.coordinateSystem), at: index)
         }
     }
 }

--- a/Sources/GeoFeatures/Point+Geometry.swift
+++ b/Sources/GeoFeatures/Point+Geometry.swift
@@ -37,7 +37,7 @@ extension Point: Geometry {
 
     public
     func boundary() -> Geometry {
-        return MultiPoint<CoordinateType>(precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem)
+        return MultiPoint<CoordinateType>(precision: self.precision, coordinateSystem: self.coordinateSystem)
     }
 
     public

--- a/Sources/GeoFeatures/Point.swift
+++ b/Sources/GeoFeatures/Point.swift
@@ -29,7 +29,7 @@ import Swift
 public struct Point<CoordinateType: Coordinate & CopyConstructable> {
 
     public let precision: Precision
-    public let coordinateReferenceSystem: CoordinateReferenceSystem
+    public let coordinateSystem: CoordinateSystem
 
     public var x: Double { get { return coordinate.x } }
     public var y: Double { get { return coordinate.y } }
@@ -37,10 +37,10 @@ public struct Point<CoordinateType: Coordinate & CopyConstructable> {
     ///
     /// Constructs a Point with another Point of the same type.
     ///
-    public init(other: Point<CoordinateType>, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) {
+    public init(other: Point<CoordinateType>, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) {
 
         self.precision = precision
-        self.coordinateReferenceSystem = coordinateReferenceSystem
+        self.coordinateSystem = coordinateSystem
 
         self.coordinate = CoordinateType(other: other.coordinate, precision: precision)
     }
@@ -48,10 +48,10 @@ public struct Point<CoordinateType: Coordinate & CopyConstructable> {
     ///
     /// Constructs a Point with a Coordinate of type CoordinateType.
     ///
-    public init(coordinate: CoordinateType, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) {
+    public init(coordinate: CoordinateType, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) {
 
         self.precision = precision
-        self.coordinateReferenceSystem = coordinateReferenceSystem
+        self.coordinateSystem = coordinateSystem
 
         self.coordinate = CoordinateType(other: coordinate, precision: precision)
     }
@@ -69,7 +69,7 @@ extension Point where CoordinateType: Measured {
 
 extension Point where CoordinateType: TupleConvertible {
 
-    public init(coordinate: CoordinateType.TupleType, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) {
+    public init(coordinate: CoordinateType.TupleType, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) {
         self.init(coordinate: CoordinateType(tuple: coordinate, precision: precision))
     }
 }

--- a/Sources/GeoFeatures/Polygon+Geometry.swift
+++ b/Sources/GeoFeatures/Polygon+Geometry.swift
@@ -38,10 +38,10 @@ extension Polygon: Geometry {
 
         return buffer.withUnsafeMutablePointers { (header, elements) -> MultiLineString<CoordinateType> in
 
-            var multiLineString = MultiLineString<CoordinateType>(precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem)
+            var multiLineString = MultiLineString<CoordinateType>(precision: self.precision, coordinateSystem: self.coordinateSystem)
 
             for i in 0..<header.pointee.count {
-                multiLineString.append(LineString<CoordinateType>(elements: elements[i], precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem))
+                multiLineString.append(LineString<CoordinateType>(elements: elements[i], precision: self.precision, coordinateSystem: self.coordinateSystem))
             }
             return multiLineString
         }

--- a/Sources/GeoFeatures/Polygon.swift
+++ b/Sources/GeoFeatures/Polygon.swift
@@ -39,11 +39,11 @@ public struct Polygon<CoordinateType: Coordinate & CopyConstructable> {
     public let precision: Precision
 
     /**
-        - returns: The `CoordinateReferenceSystem` of this Polygon
+        - returns: The `CoordinateSystem` of this Polygon
 
-        - seealso: `CoordinateReferenceSystem`
+        - seealso: `CoordinateSystem`
      */
-    public let coordinateReferenceSystem: CoordinateReferenceSystem
+    public let coordinateSystem: CoordinateSystem
 
     /**
         - returns: The `LinearRing` representing the outerRing of this Polygon
@@ -55,7 +55,7 @@ public struct Polygon<CoordinateType: Coordinate & CopyConstructable> {
             if buffer.header.count > 0 {
                 return buffer.withUnsafeMutablePointerToElements { $0[0] }
             }
-            return RingType(precision: self.precision, coordinateReferenceSystem: self.coordinateReferenceSystem)
+            return RingType(precision: self.precision, coordinateSystem: self.coordinateSystem)
         }
     }
 
@@ -85,15 +85,15 @@ public struct Polygon<CoordinateType: Coordinate & CopyConstructable> {
 
         - parameters:
             - precision: The `Precision` model this polygon should use in calculations on it's coordinates.
-            - coordinateReferenceSystem: The 'CoordinateReferenceSystem` this polygon should use in calculations on it's coordinates.
+            - coordinateSystem: The 'CoordinateSystem` this polygon should use in calculations on it's coordinates.
 
         - seealso: `CollectionType`
-        - seealso: `CoordinateReferenceSystem`
+        - seealso: `CoordinateSystem`
         - seealso: `Precision`
      */
-    public init (precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) {
+    public init (precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) {
         self.precision = precision
-        self.coordinateReferenceSystem = coordinateReferenceSystem
+        self.coordinateSystem = coordinateSystem
 
         self.buffer = BufferType.create(minimumCapacity: 8) { newBuffer in CollectionBufferHeader(capacity: newBuffer.capacity, count: 0) } as! BufferType // swiftlint:disable:this force_cast
     }
@@ -104,14 +104,14 @@ public struct Polygon<CoordinateType: Coordinate & CopyConstructable> {
      - parameters:
         - other: The Polygon of the same type that you want to construct a new Polygon from.
         - precision: The `Precision` model this polygon should use in calculations on it's coordinates.
-        - coordinateReferenceSystem: The 'CoordinateReferenceSystem` this polygon should use in calculations on it's coordinates.
+        - coordinateSystem: The 'CoordinateSystem` this polygon should use in calculations on it's coordinates.
 
-     - seealso: `CoordinateReferenceSystem`
+     - seealso: `CoordinateSystem`
      - seealso: `Precision`
      */
-    public init(other: Polygon<CoordinateType>, precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) {
+    public init(other: Polygon<CoordinateType>, precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
         self.buffer = other.buffer
     }
@@ -124,22 +124,22 @@ public struct Polygon<CoordinateType: Coordinate & CopyConstructable> {
             - outerRing: A `CollectionType` who's elements are of type `CoordinateType`.
             - innerRings: An `Array` of `CollectionType` who's elements are of type `CoordinateType`.
             - precision: The `Precision` model this polygon should use in calculations on it's coordinates.
-            - coordinateReferenceSystem: The 'CoordinateReferenceSystem` this polygon should use in calculations on it's coordinates.
+            - coordinateSystem: The 'CoordinateSystem` this polygon should use in calculations on it's coordinates.
 
         - seealso: `CollectionType`
-        - seealso: `CoordinateReferenceSystem`
+        - seealso: `CoordinateSystem`
         - seealso: `Precision`
      */
-    public init<C: Swift.Collection>(outerRing: C, innerRings: [C] = [], precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) where C.Iterator.Element == CoordinateType {
+    public init<C: Swift.Collection>(outerRing: C, innerRings: [C] = [], precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) where C.Iterator.Element == CoordinateType {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
-        buffer.append(RingType(elements: outerRing, precision: precision, coordinateReferenceSystem: coordinateReferenceSystem))
+        buffer.append(RingType(elements: outerRing, precision: precision, coordinateSystem: coordinateSystem))
 
         var innerRingsGenerator = innerRings.makeIterator()
 
         while let ring = innerRingsGenerator.next() {
-            buffer.append(RingType(elements: ring, precision: precision, coordinateReferenceSystem: coordinateReferenceSystem))
+            buffer.append(RingType(elements: ring, precision: precision, coordinateSystem: coordinateSystem))
         }
     }
 
@@ -157,35 +157,35 @@ extension Polygon where CoordinateType: TupleConvertible {
             - outerRing: A `CollectionType` who's elements are of type `CoordinateType.TupleType`.
             - innerRings: An `Array` of `CollectionType` who's elements are of type `CoordinateType.TupleType`.
             - precision: The `Precision` model this polygon should use in calculations on it's coordinates.
-            - coordinateReferenceSystem: The 'CoordinateReferenceSystem` this polygon should use in calculations on it's coordinates.
+            - coordinateSystem: The 'CoordinateSystem` this polygon should use in calculations on it's coordinates.
 
         - seealso: `CollectionType`
-        - seealso: `CoordinateReferenceSystem`
+        - seealso: `CoordinateSystem`
         - seealso: `Precision`
      */
-    public  init<C: Swift.Collection>(outerRing: C, innerRings: [C] = [], precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) where C.Iterator.Element == CoordinateType.TupleType {
+    public  init<C: Swift.Collection>(outerRing: C, innerRings: [C] = [], precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) where C.Iterator.Element == CoordinateType.TupleType {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
-        buffer.append(RingType(elements: outerRing, precision: precision, coordinateReferenceSystem: coordinateReferenceSystem))
+        buffer.append(RingType(elements: outerRing, precision: precision, coordinateSystem: coordinateSystem))
 
         var innerRingsGenerator = innerRings.makeIterator()
 
         while let ring = innerRingsGenerator.next() {
-            buffer.append(RingType(elements: ring, precision: precision, coordinateReferenceSystem: coordinateReferenceSystem))
+            buffer.append(RingType(elements: ring, precision: precision, coordinateSystem: coordinateSystem))
         }
     }
 
-    public  init<C: Swift.Collection>(rings: (C,[C]), precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) where C.Iterator.Element == CoordinateType.TupleType {
+    public  init<C: Swift.Collection>(rings: (C,[C]), precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) where C.Iterator.Element == CoordinateType.TupleType {
 
-        self.init(precision: precision, coordinateReferenceSystem: coordinateReferenceSystem)
+        self.init(precision: precision, coordinateSystem: coordinateSystem)
 
-        buffer.append(RingType(elements: rings.0, precision: precision, coordinateReferenceSystem: coordinateReferenceSystem))
+        buffer.append(RingType(elements: rings.0, precision: precision, coordinateSystem: coordinateSystem))
 
         var innerRingsGenerator = rings.1.makeIterator()
 
         while let ring = innerRingsGenerator.next() {
-            buffer.append(RingType(elements: ring, precision: precision, coordinateReferenceSystem: coordinateReferenceSystem))
+            buffer.append(RingType(elements: ring, precision: precision, coordinateSystem: coordinateSystem))
         }
     }
 }

--- a/Sources/GeoFeatures/Surface.swift
+++ b/Sources/GeoFeatures/Surface.swift
@@ -22,7 +22,7 @@ import Swift
 public protocol Surface {
 
     /**
-        The area of this Surface calaculated using its associated CoordinateReferenceSystem.
+        The area of this Surface calaculated using its associated CoordinateSystem.
     */
 
     func area() -> Double

--- a/Sources/GeoFeatures/WKTReader.swift
+++ b/Sources/GeoFeatures/WKTReader.swift
@@ -86,7 +86,7 @@ private class WKT: Token, CustomStringConvertible {
 ///
 public class WKTReader<CoordinateType: Coordinate & CopyConstructable & _ArrayConstructable> {
 
-    fileprivate let crs: CoordinateReferenceSystem
+    fileprivate let cs: CoordinateSystem
     fileprivate let precision: Precision
 
     ///
@@ -94,13 +94,13 @@ public class WKTReader<CoordinateType: Coordinate & CopyConstructable & _ArrayCo
     ///
     /// - Parameters:
     ///     - precision: The `Precision` model that should used for all coordinates.
-    ///     - coordinateReferenceSystem: The 'CoordinateReferenceSystem` the result Geometries should use in calculations on their coordinates.
+    ///     - coordinateSystem: The 'CoordinateSystem` the result Geometries should use in calculations on their coordinates.
     ///
     /// - SeeAlso: `Precision`
-    /// - SeeAlso: `CoordinateReferenceSystem`
+    /// - SeeAlso: `CoordinateSystem`
     ///
-    public init(precision: Precision = defaultPrecision, coordinateReferenceSystem: CoordinateReferenceSystem = defaultCoordinateReferenceSystem) {
-        self.crs = coordinateReferenceSystem
+    public init(precision: Precision = defaultPrecision, coordinateSystem: CoordinateSystem = defaultCoordinateSystem) {
+        self.cs = coordinateSystem
         self.precision = precision
     }
 
@@ -205,7 +205,7 @@ public class WKTReader<CoordinateType: Coordinate & CopyConstructable & _ArrayCo
         if tokenizer.accept(.RIGHT_PAREN) == nil {
             throw WKTReaderError.unexpectedToken(errorMessage(tokenizer, expectedToken: .RIGHT_PAREN))
         }
-        return Point<CoordinateType>(coordinate: coordinate, precision: precision, coordinateReferenceSystem: crs)
+        return Point<CoordinateType>(coordinate: coordinate, precision: precision, coordinateSystem: cs)
     }
 
     // BNF: <linestring tagged text> ::= linestring <linestring text>
@@ -218,7 +218,7 @@ public class WKTReader<CoordinateType: Coordinate & CopyConstructable & _ArrayCo
     fileprivate func lineStringText(_ tokenizer: Tokenizer<WKT>, require: (z: Bool, m: Bool)) throws -> LineString<CoordinateType> {
 
         if tokenizer.accept(.EMPTY) != nil {
-            return LineString<CoordinateType>(precision: precision, coordinateReferenceSystem: crs)
+            return LineString<CoordinateType>(precision: precision, coordinateSystem: cs)
         }
 
         if tokenizer.accept(.LEFT_PAREN) == nil {
@@ -244,7 +244,7 @@ public class WKTReader<CoordinateType: Coordinate & CopyConstructable & _ArrayCo
         if tokenizer.accept(.RIGHT_PAREN) == nil {
             throw WKTReaderError.unexpectedToken(errorMessage(tokenizer, expectedToken: .RIGHT_PAREN))
         }
-        return LineString<CoordinateType>(elements: coordinates, precision: precision, coordinateReferenceSystem: crs)
+        return LineString<CoordinateType>(elements: coordinates, precision: precision, coordinateSystem: cs)
     }
 
     // BNF: None defined by OGC
@@ -257,7 +257,7 @@ public class WKTReader<CoordinateType: Coordinate & CopyConstructable & _ArrayCo
     fileprivate func linearRingText(_ tokenizer: Tokenizer<WKT>, require: (z: Bool, m: Bool)) throws -> LinearRing<CoordinateType> {
 
         if tokenizer.accept(.EMPTY) != nil {
-            return LinearRing<CoordinateType>(precision: precision, coordinateReferenceSystem: crs)
+            return LinearRing<CoordinateType>(precision: precision, coordinateSystem: cs)
         }
 
         if tokenizer.accept(.LEFT_PAREN) == nil {
@@ -283,7 +283,7 @@ public class WKTReader<CoordinateType: Coordinate & CopyConstructable & _ArrayCo
         if tokenizer.accept(.RIGHT_PAREN) == nil {
             throw WKTReaderError.unexpectedToken(errorMessage(tokenizer, expectedToken: .RIGHT_PAREN))
         }
-        return LinearRing<CoordinateType>(elements: coordinates, precision: precision, coordinateReferenceSystem: crs)
+        return LinearRing<CoordinateType>(elements: coordinates, precision: precision, coordinateSystem: cs)
     }
 
     // BNF: <polygon tagged text> ::= polygon <polygon text>
@@ -296,7 +296,7 @@ public class WKTReader<CoordinateType: Coordinate & CopyConstructable & _ArrayCo
     fileprivate func polygonText(_ tokenizer: Tokenizer<WKT>, require: (z: Bool, m: Bool)) throws -> Polygon<CoordinateType> {
 
         if tokenizer.accept(.EMPTY) != nil {
-            return Polygon<CoordinateType>(precision: precision, coordinateReferenceSystem: crs)
+            return Polygon<CoordinateType>(precision: precision, coordinateSystem: cs)
         }
 
         if tokenizer.accept(.LEFT_PAREN) == nil {
@@ -349,7 +349,7 @@ public class WKTReader<CoordinateType: Coordinate & CopyConstructable & _ArrayCo
     fileprivate func multiPointText(_ tokenizer: Tokenizer<WKT>, require: (z: Bool, m: Bool)) throws -> MultiPoint<CoordinateType> {
 
         if tokenizer.accept(.EMPTY) != nil {
-            return MultiPoint<CoordinateType>(precision: precision, coordinateReferenceSystem: crs)
+            return MultiPoint<CoordinateType>(precision: precision, coordinateSystem: cs)
         }
 
         if tokenizer.accept(.LEFT_PAREN) == nil {
@@ -375,7 +375,7 @@ public class WKTReader<CoordinateType: Coordinate & CopyConstructable & _ArrayCo
         if tokenizer.accept(.RIGHT_PAREN) == nil {
             throw WKTReaderError.unexpectedToken(errorMessage(tokenizer, expectedToken: .RIGHT_PAREN))
         }
-        return MultiPoint<CoordinateType>(elements: elements, precision: precision, coordinateReferenceSystem: crs)
+        return MultiPoint<CoordinateType>(elements: elements, precision: precision, coordinateSystem: cs)
     }
 
     // BNF: <multilinestring tagged text> ::= multilinestring <multilinestring text>
@@ -388,7 +388,7 @@ public class WKTReader<CoordinateType: Coordinate & CopyConstructable & _ArrayCo
     fileprivate func multiLineStringText(_ tokenizer: Tokenizer<WKT>, require: (z: Bool, m: Bool)) throws -> MultiLineString<CoordinateType> {
 
         if tokenizer.accept(.EMPTY) != nil {
-            return MultiLineString<CoordinateType>(precision: precision, coordinateReferenceSystem: crs)
+            return MultiLineString<CoordinateType>(precision: precision, coordinateSystem: cs)
         }
 
         if tokenizer.accept(.LEFT_PAREN) == nil {
@@ -413,7 +413,7 @@ public class WKTReader<CoordinateType: Coordinate & CopyConstructable & _ArrayCo
         if tokenizer.accept(.RIGHT_PAREN) == nil {
             throw WKTReaderError.unexpectedToken(errorMessage(tokenizer, expectedToken: .RIGHT_PAREN))
         }
-        return MultiLineString<CoordinateType>(elements: elements, precision: precision, coordinateReferenceSystem: crs)
+        return MultiLineString<CoordinateType>(elements: elements, precision: precision, coordinateSystem: cs)
     }
 
     // BNF: <multipolygon tagged text> ::= multipolygon <multipolygon text>
@@ -426,7 +426,7 @@ public class WKTReader<CoordinateType: Coordinate & CopyConstructable & _ArrayCo
     fileprivate func multiPolygonText(_ tokenizer: Tokenizer<WKT>, require: (z: Bool, m: Bool)) throws -> MultiPolygon<CoordinateType> {
 
         if tokenizer.accept(.EMPTY) != nil {
-            return MultiPolygon<CoordinateType>(precision: precision, coordinateReferenceSystem: crs)
+            return MultiPolygon<CoordinateType>(precision: precision, coordinateSystem: cs)
         }
 
         if tokenizer.accept(.LEFT_PAREN) == nil {
@@ -466,7 +466,7 @@ public class WKTReader<CoordinateType: Coordinate & CopyConstructable & _ArrayCo
     fileprivate func geometryCollectionText(_ tokenizer: Tokenizer<WKT>, require: (z: Bool, m: Bool)) throws -> GeometryCollection {
 
         if tokenizer.accept(.EMPTY) != nil {
-            return GeometryCollection(precision: precision, coordinateReferenceSystem: crs)
+            return GeometryCollection(precision: precision, coordinateSystem: cs)
         }
 
         if tokenizer.accept(.LEFT_PAREN) == nil {
@@ -524,7 +524,7 @@ public class WKTReader<CoordinateType: Coordinate & CopyConstructable & _ArrayCo
         if tokenizer.accept(.RIGHT_PAREN) == nil {
             throw WKTReaderError.unexpectedToken(errorMessage(tokenizer, expectedToken: .RIGHT_PAREN))
         }
-        return GeometryCollection(elements: elements, precision: precision, coordinateReferenceSystem: crs)
+        return GeometryCollection(elements: elements, precision: precision, coordinateSystem: cs)
     }
 
     // BNF: <point> ::= <x> <y>

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -124,8 +124,8 @@ valid_docs:
 
 variable_name:
   min_length:
-    warning: 3
-    error: 3
+    warning: 2
+    error: 2
   max_length:
     warning: 40
     error: 60

--- a/Tests/GeoFeaturesTests/CoordinateCollectionTests.swift.gyb
+++ b/Tests/GeoFeaturesTests/CoordinateCollectionTests.swift.gyb
@@ -55,7 +55,7 @@ import GeoFeatures
 
 Precision = PrecisionType + PrecisionParameters
 
-CoordinateReferenceSystem = ReferenceSystemType + ReferenceSystemParameters
+CoordinateSystem = ReferenceSystemType + ReferenceSystemParameters
 
 FunctionQualifier = CoordinateType + '_' + PrecisionType + '_' + ReferenceSystemType
 
@@ -66,13 +66,13 @@ FunctionQualifier = CoordinateType + '_' + PrecisionType + '_' + ReferenceSystem
 class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     let precision = ${Precision}
-    let crs       = ${CoordinateReferenceSystem}
+    let cs       = ${CoordinateSystem}
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(${GeometryType}<${CoordinateType}>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(${GeometryType}<${CoordinateType}>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -82,12 +82,12 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(${GeometryType}<${CoordinateType}>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? ${ReferenceSystemType}, crs)
+        XCTAssertEqual(${GeometryType}<${CoordinateType}>(coordinateSystem: cs).coordinateSystem as? ${ReferenceSystemType}, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = ${GeometryType}<${CoordinateType}>(elements: [${TestTuple0},${TestTuple1}], precision: precision, coordinateReferenceSystem: crs)
+        let input = ${GeometryType}<${CoordinateType}>(elements: [${TestTuple0},${TestTuple1}], precision: precision, coordinateSystem: cs)
         let expected = [${CoordinateType}(tuple: ${ExpectedTuple0}), ${CoordinateType}(tuple: ${ExpectedTuple1})]
 
         XCTAssertTrue(
@@ -99,8 +99,8 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = ${GeometryType}<${CoordinateType}>(other: ${GeometryType}<${CoordinateType}>(elements: [${TestTuple0},${TestTuple1}]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = ${GeometryType}<${CoordinateType}>(elements: [${ExpectedTuple0},${ExpectedTuple1}], precision: precision, coordinateReferenceSystem: crs)
+        let input = ${GeometryType}<${CoordinateType}>(other: ${GeometryType}<${CoordinateType}>(elements: [${TestTuple0},${TestTuple1}]), precision: precision, coordinateSystem: cs)
+        let expected = ${GeometryType}<${CoordinateType}>(elements: [${ExpectedTuple0},${ExpectedTuple1}], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: ${CoordinateType}, rhs: ${CoordinateType}) -> Bool in
@@ -113,7 +113,7 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateReferenceSystem: crs)
+        let input = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateSystem: cs)
         let expected = "${GeometryType}<${CoordinateType}>(${ExpectedTuple0}, ${ExpectedTuple1})"
 
         XCTAssertEqual(input.description, expected)
@@ -121,7 +121,7 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateReferenceSystem: crs)
+        let input = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateSystem: cs)
         let expected = "${GeometryType}<${CoordinateType}>(${ExpectedTuple0}, ${ExpectedTuple1})"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -131,7 +131,7 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -141,7 +141,7 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateSystem: cs)
         let expected = [${CoordinateType}(tuple: ${ExpectedTuple0})]
 
         input.append(${TestTuple0})
@@ -153,8 +153,8 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = ${GeometryType}<${CoordinateType}>(elements: [${TestTuple0},${TestTuple1}], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = ${GeometryType}<${CoordinateType}>(elements: [${TestTuple0},${TestTuple1}], precision: precision, coordinateSystem: cs)
+        var input2 = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -163,7 +163,7 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateSystem: cs)
         let expected = [${CoordinateType}(tuple: ${ExpectedTuple0}), ${CoordinateType}(tuple: ${ExpectedTuple1})]
 
         input.append(contentsOf: expected)
@@ -175,8 +175,8 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${ExpectedTuple0}), ${CoordinateType}(tuple: ${ExpectedTuple1})], precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateSystem: cs)
+        let expected = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${ExpectedTuple0}), ${CoordinateType}(tuple: ${ExpectedTuple1})], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [${ExpectedTuple0}, ${ExpectedTuple1}])
 
@@ -185,7 +185,7 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateSystem: cs)
         let expected = [${CoordinateType}(tuple: ${ExpectedTuple1}), ${CoordinateType}(tuple: ${ExpectedTuple0}), ${CoordinateType}(tuple: ${ExpectedTuple1})]
 
         input.insert(${CoordinateType}(tuple: ${TestTuple1}), at: 0)
@@ -197,7 +197,7 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateSystem: cs)
         let expected = [${CoordinateType}(tuple: ${ExpectedTuple1}), ${CoordinateType}(tuple: ${ExpectedTuple0}), ${CoordinateType}(tuple: ${ExpectedTuple1})]
 
         input.insert(${TestTuple1}, at: 0)
@@ -209,8 +209,8 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateReferenceSystem: crs)
-        let expected = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${ExpectedTuple1})], precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateSystem: cs)
+        let expected = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${ExpectedTuple1})], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -219,8 +219,8 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateReferenceSystem: crs)
-        let expected = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${ExpectedTuple0})], precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateSystem: cs)
+        let expected = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${ExpectedTuple0})], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -229,8 +229,8 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateReferenceSystem: crs)
-        let expected = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateSystem: cs)
+        let expected = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -239,7 +239,7 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -251,14 +251,14 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = ${GeometryType}<${CoordinateType}>(elements: [${TestTuple0},${TestTuple1}], precision: precision, coordinateReferenceSystem: crs)
+        let input = ${GeometryType}<${CoordinateType}>(elements: [${TestTuple0},${TestTuple1}], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], ${CoordinateType}(tuple: ${ExpectedTuple1}))
     }
 
     func testSubscript_Set() {
 
-        var input = ${GeometryType}<${CoordinateType}>(elements: [${TestTuple0},${TestTuple1}], precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}<${CoordinateType}>(elements: [${TestTuple0},${TestTuple1}], precision: precision, coordinateSystem: cs)
 
         input[1] = ${CoordinateType}(tuple: ${TestTuple0})
 
@@ -267,29 +267,29 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateReferenceSystem: crs).equals(${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${ExpectedTuple0}), ${CoordinateType}(tuple: ${ExpectedTuple1})], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateSystem: cs).equals(${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${ExpectedTuple0}), ${CoordinateType}(tuple: ${ExpectedTuple1})], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(${GeometryType}<${CoordinateType}>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(${GeometryType}<${CoordinateType}>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(${GeometryType}<${CoordinateType}>(elements: [${CoordinateType}(tuple: ${TestTuple0}), ${CoordinateType}(tuple: ${TestTuple1})], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -302,7 +302,7 @@ class ${Self}_${FunctionQualifier}_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}<${CoordinateType}>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity

--- a/Tests/GeoFeaturesTests/CoordinateReferenceSystemTests.swift
+++ b/Tests/GeoFeaturesTests/CoordinateReferenceSystemTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 import GeoFeatures
 
-fileprivate struct DummyCoordinateReferenceSystem: CoordinateReferenceSystem, Equatable, Hashable {
+fileprivate struct DummyCoordinateReferenceSystem: CoordinateSystem, Equatable, Hashable {
     public var hashValue: Int { get { return String(reflecting: self).hashValue } }
 }
 

--- a/Tests/GeoFeaturesTests/GeoJSONReaderTests.swift
+++ b/Tests/GeoFeaturesTests/GeoJSONReaderTests.swift
@@ -21,7 +21,7 @@ class GeoJSONReader_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
     private typealias CoordinateType = Coordinate2D
     private typealias GeoJSONReaderType = GeoJSONReader<CoordinateType>
 
-    private var reader = GeoJSONReaderType(precision: FloatingPrecision(), coordinateReferenceSystem: Cartesian())
+    private var reader = GeoJSONReaderType(precision: FloatingPrecision(), coordinateSystem: Cartesian())
 
     // MARK: - Negative Tests
 
@@ -253,7 +253,7 @@ class GeoJSONReader_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
     private typealias CoordinateType = Coordinate3DM
     private typealias GeoJSONReaderType = GeoJSONReader<CoordinateType>
 
-    private var reader = GeoJSONReaderType(precision: FixedPrecision(scale: 100), coordinateReferenceSystem: Cartesian())
+    private var reader = GeoJSONReaderType(precision: FixedPrecision(scale: 100), coordinateSystem: Cartesian())
 
     // MARK: negative Tests
 

--- a/Tests/GeoFeaturesTests/GeometryCollection+GeometryTests.swift
+++ b/Tests/GeoFeaturesTests/GeometryCollection+GeometryTests.swift
@@ -30,56 +30,56 @@ import GeoFeatures
 class GeometryCollection_Geometry_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(GeometryCollection(precision: precision, coordinateReferenceSystem: crs).dimension, Dimension.empty)
+        XCTAssertEqual(GeometryCollection(precision: precision, coordinateSystem: cs).dimension, Dimension.empty)
     }
 
     func testDimension_Homogeneous_Point () {
-        XCTAssertEqual(GeometryCollection(elements: [Point<Coordinate2D>(coordinate: (x: 1, y: 1))] as [Geometry], precision: precision, coordinateReferenceSystem: crs).dimension, Dimension.zero)
+        XCTAssertEqual(GeometryCollection(elements: [Point<Coordinate2D>(coordinate: (x: 1, y: 1))] as [Geometry], precision: precision, coordinateSystem: cs).dimension, Dimension.zero)
     }
 
     func testDimension_Homogeneous_LineString () {
-        XCTAssertEqual(GeometryCollection(elements: [LineString<Coordinate2D>()] as [Geometry], precision: precision, coordinateReferenceSystem: crs).dimension, Dimension.one)
+        XCTAssertEqual(GeometryCollection(elements: [LineString<Coordinate2D>()] as [Geometry], precision: precision, coordinateSystem: cs).dimension, Dimension.one)
     }
 
     func testDimension_Homogeneous_Polygon () {
-        XCTAssertEqual(GeometryCollection(elements: [Polygon<Coordinate2D>()] as [Geometry], precision: precision, coordinateReferenceSystem: crs).dimension, Dimension.two)
+        XCTAssertEqual(GeometryCollection(elements: [Polygon<Coordinate2D>()] as [Geometry], precision: precision, coordinateSystem: cs).dimension, Dimension.two)
     }
 
     func testDimension_Non_Homogeneous_Point_Polygon () {
-        XCTAssertEqual(GeometryCollection(elements: [Point<Coordinate2D>(coordinate: (x: 1, y: 1)), Polygon<Coordinate2D>()] as [Geometry], precision: precision, coordinateReferenceSystem: crs).dimension, Dimension.two)
+        XCTAssertEqual(GeometryCollection(elements: [Point<Coordinate2D>(coordinate: (x: 1, y: 1)), Polygon<Coordinate2D>()] as [Geometry], precision: precision, coordinateSystem: cs).dimension, Dimension.two)
     }
 
     func testDimension_Non_Homogeneous_Point_LineString () {
-        XCTAssertEqual(GeometryCollection(elements: [Point<Coordinate2D>(coordinate: (x: 1, y: 1)), LineString<Coordinate2D>()] as [Geometry], precision: precision, coordinateReferenceSystem: crs).dimension, Dimension.one)
+        XCTAssertEqual(GeometryCollection(elements: [Point<Coordinate2D>(coordinate: (x: 1, y: 1)), LineString<Coordinate2D>()] as [Geometry], precision: precision, coordinateSystem: cs).dimension, Dimension.one)
     }
 
     func testBoundary() {
-        let input = GeometryCollection(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))]  as [Geometry], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = GeometryCollection(precision: precision, coordinateReferenceSystem: crs) // GeometryCollection will always return an empty GeometryCollection for boundary
+        let input = GeometryCollection(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))]  as [Geometry], precision: precision, coordinateSystem: cs).boundary()
+        let expected = GeometryCollection(precision: precision, coordinateSystem: cs) // GeometryCollection will always return an empty GeometryCollection for boundary
 
         XCTAssertTrue(input == expected, "\(input) is not equal to \(expected)")
     }
 
     func testEqual_True() {
-        let input1 = GeometryCollection(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))]  as [Geometry], precision: precision, coordinateReferenceSystem: crs)
-        let input2 = GeometryCollection(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))]  as [Geometry], precision: precision, coordinateReferenceSystem: crs)
+        let input1 = GeometryCollection(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))]  as [Geometry], precision: precision, coordinateSystem: cs)
+        let input2 = GeometryCollection(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))]  as [Geometry], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input1, input2)
     }
 
     func testEqual_SameTypes_False() {
-        let input1            = GeometryCollection(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))]  as [Geometry], precision: precision, coordinateReferenceSystem: crs)
-        let input2: Geometry  = GeometryCollection(precision: precision, coordinateReferenceSystem: crs)
+        let input1            = GeometryCollection(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))]  as [Geometry], precision: precision, coordinateSystem: cs)
+        let input2: Geometry  = GeometryCollection(precision: precision, coordinateSystem: cs)
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
     }
 
     func testEqual_DifferentTypes_False() {
-        let input1            = GeometryCollection(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))]  as [Geometry], precision: precision, coordinateReferenceSystem: crs)
-        let input2: Geometry  = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input1            = GeometryCollection(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))]  as [Geometry], precision: precision, coordinateSystem: cs)
+        let input2: Geometry  = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
     }
@@ -90,29 +90,29 @@ class GeometryCollection_Geometry_FloatingPrecision_Cartesian_Tests: XCTestCase 
 class GeometryCollection_Geometry_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(GeometryCollection(precision: precision, coordinateReferenceSystem: crs).dimension, Dimension.empty)
+        XCTAssertEqual(GeometryCollection(precision: precision, coordinateSystem: cs).dimension, Dimension.empty)
     }
 
     func testDimension_Homogeneous_Point () {
-        XCTAssertEqual(GeometryCollection(elements: [Point<Coordinate2D>(coordinate: (x: 1, y: 1))] as [Geometry], precision: precision, coordinateReferenceSystem: crs).dimension, Dimension.zero)
+        XCTAssertEqual(GeometryCollection(elements: [Point<Coordinate2D>(coordinate: (x: 1, y: 1))] as [Geometry], precision: precision, coordinateSystem: cs).dimension, Dimension.zero)
     }
 
     func testDimension_Homogeneous_LineString () {
-        XCTAssertEqual(GeometryCollection(elements: [LineString<Coordinate2D>()] as [Geometry], precision: precision, coordinateReferenceSystem: crs).dimension, Dimension.one)
+        XCTAssertEqual(GeometryCollection(elements: [LineString<Coordinate2D>()] as [Geometry], precision: precision, coordinateSystem: cs).dimension, Dimension.one)
     }
 
     func testDimension_Homogeneous_Polygon () {
-        XCTAssertEqual(GeometryCollection(elements: [Polygon<Coordinate2D>()] as [Geometry], precision: precision, coordinateReferenceSystem: crs).dimension, Dimension.two)
+        XCTAssertEqual(GeometryCollection(elements: [Polygon<Coordinate2D>()] as [Geometry], precision: precision, coordinateSystem: cs).dimension, Dimension.two)
     }
 
     func testDimension_Non_Homogeneous_Point_Polygon () {
-        XCTAssertEqual(GeometryCollection(elements: [Point<Coordinate2D>(coordinate: (x: 1, y: 1)), Polygon<Coordinate2D>()] as [Geometry], precision: precision, coordinateReferenceSystem: crs).dimension, Dimension.two)
+        XCTAssertEqual(GeometryCollection(elements: [Point<Coordinate2D>(coordinate: (x: 1, y: 1)), Polygon<Coordinate2D>()] as [Geometry], precision: precision, coordinateSystem: cs).dimension, Dimension.two)
     }
 
     func testDimension_Non_Homogeneous_Point_LineString () {
-        XCTAssertEqual(GeometryCollection(elements: [Point<Coordinate2D>(coordinate: (x: 1, y: 1)), LineString<Coordinate2D>()] as [Geometry], precision: precision, coordinateReferenceSystem: crs).dimension, Dimension.one)
+        XCTAssertEqual(GeometryCollection(elements: [Point<Coordinate2D>(coordinate: (x: 1, y: 1)), LineString<Coordinate2D>()] as [Geometry], precision: precision, coordinateSystem: cs).dimension, Dimension.one)
     }
 }

--- a/Tests/GeoFeaturesTests/GeometryCollectionTests.swift
+++ b/Tests/GeoFeaturesTests/GeometryCollectionTests.swift
@@ -37,7 +37,7 @@ import GeoFeatures
 class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
@@ -50,16 +50,16 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
     func testInit_NoArg_Defaults() {
         let input    = GeometryCollection()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? FloatingPrecision, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = GeometryCollection(precision: precision, coordinateReferenceSystem: crs)
+        let input = GeometryCollection(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? FloatingPrecision, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Precision() {
@@ -70,15 +70,15 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
     }
 
     func testInit_CRS() {
-        let input = GeometryCollection(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = GeometryCollection(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, expected)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, expected)
     }
 
     func testInit_Tuple() {
 
-        let input = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
+        let input = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
         let expected = [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element]
 
         XCTAssertTrue(
@@ -92,7 +92,7 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testDescription() {
 
-        let input    = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
+        let input    = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
         let expected = "GeometryCollection(Polygon<Coordinate2D>([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []), Polygon<Coordinate2D>([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))"
 
         XCTAssertEqual(input.description, expected)
@@ -100,7 +100,7 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testDebugDescription() {
 
-        let input    = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
+        let input    = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
         let expected = "GeometryCollection(Polygon<Coordinate2D>([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []), Polygon<Coordinate2D>([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -110,7 +110,7 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testReserveCapacity() {
 
-        var input = GeometryCollection(precision: precision, coordinateReferenceSystem: crs)
+        var input = GeometryCollection(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -120,7 +120,7 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testAppend() {
 
-        var input    = GeometryCollection(precision: precision, coordinateReferenceSystem: crs)
+        var input    = GeometryCollection(precision: precision, coordinateSystem: cs)
         let expected = [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element]
 
         input.append(Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])))
@@ -132,8 +132,8 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testAppend_ContentsOf() {
 
-        let input1 = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = GeometryCollection(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
+        var input2 = GeometryCollection(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -142,7 +142,7 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testInsert_2ExistingElements() {
 
-        var input = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
+        var input = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
         let expected = [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element]
 
         input.insert(Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), at: 0)
@@ -154,7 +154,7 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testInsert_1ExistingElements() {
 
-        var input = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
+        var input = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
         let expected = [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element]
 
         input.insert(Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), at: 0)
@@ -166,8 +166,8 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testRemove() {
 
-        var input =  GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
-        let expected = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
+        var input =  GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
+        let expected = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -176,8 +176,8 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testRemoveLast() {
 
-        var input =  GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
-        let expected = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
+        var input =  GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
+        let expected = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -186,8 +186,8 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testRemoveAll() {
 
-        var input =  GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
-        let expected =  GeometryCollection(precision: precision, coordinateReferenceSystem: crs)
+        var input =  GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
+        let expected =  GeometryCollection(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -196,7 +196,7 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testRemoveAll_KeepCapacity() {
 
-        var input =  GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
+        var input =  GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -208,7 +208,7 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testSubscript_Get() {
 
-        let input    = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
+        let input    = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
         let expected = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])) as GeometryCollection.Element
 
         XCTAssertTrue(input[1].equals(expected))
@@ -216,8 +216,8 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testSubscript_Set() {
 
-        var input    = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
-        let expected = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
+        var input    = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
+        let expected = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
 
         input[1] = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])) as GeometryCollection.Element
 
@@ -226,15 +226,15 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testEquals() {
 
-        let input    = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
-        let expected = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
+        let input    = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
+        let expected = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
     }
 
     func testIsEmpty() {
 
-        let input = GeometryCollection(precision: precision, coordinateReferenceSystem: crs)
+        let input = GeometryCollection(precision: precision, coordinateSystem: cs)
         let expected = true
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -242,7 +242,7 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testIsEmpty_False() {
 
-        let input    = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
+        let input    = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
         let expected = false
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -250,7 +250,7 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testCount() {
 
-        let input    = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateReferenceSystem: crs)
+        let input    = GeometryCollection(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))] as [GeometryCollection.Element], precision: precision, coordinateSystem: cs)
         let expected = 2
 
         XCTAssertEqual(input.count, expected)
@@ -260,7 +260,7 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testEnsureUniquelyReferenced() {
 
-        var input = GeometryCollection(precision: precision, coordinateReferenceSystem: crs)
+        var input = GeometryCollection(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -273,7 +273,7 @@ class GeometryCollection_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 
     func testResizeIfNeeded() {
 
-        var input = GeometryCollection(precision: precision, coordinateReferenceSystem: crs)
+        var input = GeometryCollection(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity

--- a/Tests/GeoFeaturesTests/GeometryCollectionTests.swift.gyb
+++ b/Tests/GeoFeaturesTests/GeometryCollectionTests.swift.gyb
@@ -70,7 +70,7 @@ if GeometryIsGeneric:
     GeometryType = GeometryType + '<' + CoordinateType + '>'
 
 Precision                 = PrecisionType + PrecisionParameters
-CoordinateReferenceSystem = ReferenceSystemType + ReferenceSystemParameters
+CoordinateSystem = ReferenceSystemType + ReferenceSystemParameters
 ClassQualifier            = CoordinateType + '_' + PrecisionType + '_' + ReferenceSystemType
 
 }%
@@ -79,7 +79,7 @@ ClassQualifier            = CoordinateType + '_' + PrecisionType + '_' + Referen
 class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     let precision = ${Precision}
-    let crs       = ${CoordinateReferenceSystem}
+    let cs       = ${CoordinateSystem}
 
     // MARK: Construction
 
@@ -92,16 +92,16 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
     func testInit_NoArg_Defaults() {
         let input    = ${GeometryType}()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? ${PrecisionType}, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? ${ReferenceSystemType}, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? ${ReferenceSystemType}, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = ${GeometryType}(precision: precision, coordinateReferenceSystem: crs)
+        let input = ${GeometryType}(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? ${PrecisionType}, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? ${ReferenceSystemType}, crs)
+        XCTAssertEqual(input.coordinateSystem as? ${ReferenceSystemType}, cs)
     }
 
     func testInit_Precision() {
@@ -112,15 +112,15 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
     }
 
     func testInit_CRS() {
-        let input = ${GeometryType}(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = ${GeometryType}(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? ${ReferenceSystemType}, expected)
+        XCTAssertEqual(input.coordinateSystem as? ${ReferenceSystemType}, expected)
     }
 
     func testInit_Tuple() {
 
-        let input = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
+        let input = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
         let expected = [${ExpectedElement1}, ${ExpectedElement2}]${ElementArrayCast}
 
         XCTAssertTrue(
@@ -134,7 +134,7 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input    = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
+        let input    = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
         let expected = "${GeometryType}(${ExpectedElementDescription1}, ${ExpectedElementDescription2})"
 
         XCTAssertEqual(input.description, expected)
@@ -142,7 +142,7 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input    = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
+        let input    = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
         let expected = "${GeometryType}(${ExpectedElementDescription1}, ${ExpectedElementDescription2})"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -152,7 +152,7 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = ${GeometryType}(precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -162,7 +162,7 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input    = ${GeometryType}(precision: precision, coordinateReferenceSystem: crs)
+        var input    = ${GeometryType}(precision: precision, coordinateSystem: cs)
         let expected = [${ExpectedElement1}]${ElementArrayCast}
 
         input.append(${TestElement1})
@@ -174,8 +174,8 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
-        var input2 = ${GeometryType}(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
+        var input2 = ${GeometryType}(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -184,7 +184,7 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testInsert_2ExistingElements() {
 
-        var input = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
         let expected = [${ExpectedElement2}, ${ExpectedElement1}, ${ExpectedElement2}]${ElementArrayCast}
 
         input.insert(${TestElement2}, at: 0)
@@ -196,7 +196,7 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testInsert_1ExistingElements() {
 
-        var input = ${GeometryType}(elements: [${TestElement1}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}(elements: [${TestElement1}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
         let expected = [${ExpectedElement2}, ${ExpectedElement1}]${ElementArrayCast}
 
         input.insert(${TestElement2}, at: 0)
@@ -208,8 +208,8 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input =  ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
-        let expected = ${GeometryType}(elements: [${ExpectedElement2}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
+        var input =  ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
+        let expected = ${GeometryType}(elements: [${ExpectedElement2}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -218,8 +218,8 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input =  ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
-        let expected = ${GeometryType}(elements: [${ExpectedElement1}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
+        var input =  ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
+        let expected = ${GeometryType}(elements: [${ExpectedElement1}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -228,8 +228,8 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input =  ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
-        let expected =  ${GeometryType}(precision: precision, coordinateReferenceSystem: crs)
+        var input =  ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
+        let expected =  ${GeometryType}(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -238,7 +238,7 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input =  ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
+        var input =  ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -250,7 +250,7 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input    = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
+        let input    = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
         let expected = ${ExpectedElement2}${ElementCast}
 
         XCTAssertTrue(input[1].equals(expected))
@@ -258,8 +258,8 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testSubscript_Set() {
 
-        var input    = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
-        let expected = ${GeometryType}(elements: [${ExpectedElement1}, ${ExpectedElement1}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
+        var input    = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
+        let expected = ${GeometryType}(elements: [${ExpectedElement1}, ${ExpectedElement1}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
 
         input[1] = ${TestElement1}${ElementCast}
 
@@ -268,15 +268,15 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testEquals() {
 
-        let input    = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
-        let expected = ${GeometryType}(elements: [${ExpectedElement1}, ${ExpectedElement2}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
+        let input    = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
+        let expected = ${GeometryType}(elements: [${ExpectedElement1}, ${ExpectedElement2}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
     }
 
     func testIsEmpty() {
 
-        let input = ${GeometryType}(precision: precision, coordinateReferenceSystem: crs)
+        let input = ${GeometryType}(precision: precision, coordinateSystem: cs)
         let expected = true
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -284,7 +284,7 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testIsEmpty_False() {
 
-        let input    = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
+        let input    = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
         let expected = false
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -292,7 +292,7 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testCount() {
 
-        let input    = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateReferenceSystem: crs)
+        let input    = ${GeometryType}(elements: [${TestElement1}, ${TestElement2}]${ElementArrayCast}, precision: precision, coordinateSystem: cs)
         let expected = 2
 
         XCTAssertEqual(input.count, expected)
@@ -302,7 +302,7 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testEnsureUniquelyReferenced() {
 
-        var input = ${GeometryType}(precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -315,7 +315,7 @@ class ${GeometryClass}_${ClassQualifier}_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = ${GeometryType}(precision: precision, coordinateReferenceSystem: crs)
+        var input = ${GeometryType}(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity

--- a/Tests/GeoFeaturesTests/LineString+CurveTests.swift
+++ b/Tests/GeoFeaturesTests/LineString+CurveTests.swift
@@ -25,26 +25,26 @@ import GeoFeatures
 class LineString_Curve_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testLength_Test1() {
-        XCTAssertEqual(LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 1, y: 1)], precision: precision, coordinateReferenceSystem: crs).length(), 1.4142135623730951)
+        XCTAssertEqual(LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 1, y: 1)], precision: precision, coordinateSystem: cs).length(), 1.4142135623730951)
     }
 
     func testLength_Test2() {
-        XCTAssertEqual(LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2)], precision: precision, coordinateReferenceSystem: crs).length(), 2.0)
+        XCTAssertEqual(LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2)], precision: precision, coordinateSystem: cs).length(), 2.0)
     }
 
     func testLength_Test3() {
-        XCTAssertEqual(LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 7, y:0)], precision: precision, coordinateReferenceSystem: crs).length(), 7.0)
+        XCTAssertEqual(LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 7, y:0)], precision: precision, coordinateSystem: cs).length(), 7.0)
     }
 
     func testLength_Test4() {
-        XCTAssertEqual(LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 0, y: 4), (x: 0, y: 5)], precision: precision, coordinateReferenceSystem: crs).length(), 5.0)
+        XCTAssertEqual(LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 0, y: 4), (x: 0, y: 5)], precision: precision, coordinateSystem: cs).length(), 5.0)
     }
 
     func testLengthPerformance() {
-        let lineString = LineString<Coordinate2D>(elements: [(x:0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 0, y: 4), (x: 0, y: 5)], precision: precision, coordinateReferenceSystem: crs)
+        let lineString = LineString<Coordinate2D>(elements: [(x:0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 0, y: 4), (x: 0, y: 5)], precision: precision, coordinateSystem: cs)
 
         self.measure {
 
@@ -55,15 +55,15 @@ class LineString_Curve_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCas
     }
 
     func testIsClosed_Closed() {
-        XCTAssertTrue(LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 2, y: 0), (x: 0, y: 0)], precision: precision, coordinateReferenceSystem: crs).isClosed())
+        XCTAssertTrue(LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 2, y: 0), (x: 0, y: 0)], precision: precision, coordinateSystem: cs).isClosed())
     }
 
     func testIsClosed_Open() {
-        XCTAssertFalse(LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 0, y: 4), (x: 0, y: 5)], precision: precision, coordinateReferenceSystem: crs).isClosed())
+        XCTAssertFalse(LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 0, y: 4), (x: 0, y: 5)], precision: precision, coordinateSystem: cs).isClosed())
     }
 
     func testIsClosed_Empty() {
-        XCTAssertFalse(LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).isClosed())
+        XCTAssertFalse(LineString<Coordinate2D>(precision: precision, coordinateSystem: cs).isClosed())
     }
 }
 
@@ -72,10 +72,10 @@ class LineString_Curve_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCas
 class LineString_Curve_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testPerformanceLength() {
-        let lineString = LineString<Coordinate3D>(elements: [(x:0, y: 0, z: 0), (x: 0, y: 2, z: 0), (x: 0, y: 3, z: 0), (x: 0, y: 4, z: 0), (x: 0, y: 5, z:0)], precision: precision, coordinateReferenceSystem: crs)
+        let lineString = LineString<Coordinate3D>(elements: [(x:0, y: 0, z: 0), (x: 0, y: 2, z: 0), (x: 0, y: 3, z: 0), (x: 0, y: 4, z: 0), (x: 0, y: 5, z:0)], precision: precision, coordinateSystem: cs)
 
         self.measure {
 

--- a/Tests/GeoFeaturesTests/LineString+GeometryTests.swift
+++ b/Tests/GeoFeaturesTests/LineString+GeometryTests.swift
@@ -27,57 +27,57 @@ private let geometryDimension = Dimension.one    // LineString are always 1 dime
 class LineString_Geometry_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(LineString<Coordinate2D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testBoundary_1Element_Invalid() {
-        let geometry = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0)], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs) // Empty Set
+        let geometry = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0)], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs) // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_2Element() {
-        let geometry = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let geometry = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_3Element_Open() {
-        let geometry = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0), (x: 3.0, y: 3.0)], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 3.0, y: 3.0))], precision: precision, coordinateReferenceSystem: crs)
+        let geometry = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0), (x: 3.0, y: 3.0)], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 3.0, y: 3.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_4Element_Closed() {
-        let geometry = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0), (x: 3.0, y: 3.0), (x: 1.0, y: 1.0)], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs) // Empty Set
+        let geometry = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0), (x: 3.0, y: 3.0), (x: 1.0, y: 1.0)], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs) // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_Empty() {
-        let geometry = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testEqual_True() {
-        let input1 = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
-        let input2 = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
+        let input2 = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input1, input2)
      }
 
      func testEqual_False() {
-        let input1            = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
-        let input2: Geometry  = Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0), precision: precision, coordinateReferenceSystem: crs)
+        let input1            = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
+        let input2: Geometry  = Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0), precision: precision, coordinateSystem: cs)
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
      }
@@ -88,10 +88,10 @@ class LineString_Geometry_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTest
 class LineString_Geometry_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -100,10 +100,10 @@ class LineString_Geometry_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTes
 class LineString_Geometry_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(LineString<Coordinate3D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -112,10 +112,10 @@ class LineString_Geometry_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTest
 class LineString_Geometry_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -124,10 +124,10 @@ class LineString_Geometry_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTes
 class LineString_Geometry_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(LineString<Coordinate2D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -136,10 +136,10 @@ class LineString_Geometry_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCas
 class LineString_Geometry_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -148,10 +148,10 @@ class LineString_Geometry_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCa
 class LineString_Geometry_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(LineString<Coordinate3D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -160,9 +160,9 @@ class LineString_Geometry_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCas
 class LineString_Geometry_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }

--- a/Tests/GeoFeaturesTests/LineStringTests.swift
+++ b/Tests/GeoFeaturesTests/LineStringTests.swift
@@ -33,13 +33,13 @@ import GeoFeatures
 class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(LineString<Coordinate2D>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -49,12 +49,12 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(LineString<Coordinate2D>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(LineString<Coordinate2D>(coordinateSystem: cs).coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
 
         XCTAssertTrue(
@@ -66,8 +66,8 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = LineString<Coordinate2D>(other: LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2D>(other: LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)]), precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
@@ -80,7 +80,7 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "LineString<Coordinate2D>((x: 1.0, y: 1.0), (x: 2.0, y: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -88,7 +88,7 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "LineString<Coordinate2D>((x: 1.0, y: 1.0), (x: 2.0, y: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -98,7 +98,7 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -108,7 +108,7 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0))]
 
         input.append((x: 1.0, y: 1.0))
@@ -120,8 +120,8 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
+        var input2 = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -130,7 +130,7 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
 
         input.append(contentsOf: expected)
@@ -142,8 +142,8 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)])
 
@@ -152,7 +152,7 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 2.0, y: 2.0)), Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
 
         input.insert(Coordinate2D(tuple: (x: 2.0, y: 2.0)), at: 0)
@@ -164,7 +164,7 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 2.0, y: 2.0)), Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
 
         input.insert((x: 2.0, y: 2.0), at: 0)
@@ -176,8 +176,8 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -186,8 +186,8 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -196,8 +196,8 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -206,7 +206,7 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -218,14 +218,14 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], Coordinate2D(tuple: (x: 2.0, y: 2.0)))
     }
 
     func testSubscript_Set() {
 
-        var input = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
 
         input[1] = Coordinate2D(tuple: (x: 1.0, y: 1.0))
 
@@ -234,29 +234,29 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs).equals(LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs).equals(LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(LineString<Coordinate2D>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -269,7 +269,7 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -285,13 +285,13 @@ class LineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -301,12 +301,12 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(LineString<Coordinate2DM>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(LineString<Coordinate2DM>(coordinateSystem: cs).coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = LineString<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
 
         XCTAssertTrue(
@@ -318,8 +318,8 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = LineString<Coordinate2DM>(other: LineString<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2DM>(other: LineString<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)]), precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
@@ -332,7 +332,7 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "LineString<Coordinate2DM>((x: 1.0, y: 1.0, m: 1.0), (x: 2.0, y: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -340,7 +340,7 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "LineString<Coordinate2DM>((x: 1.0, y: 1.0, m: 1.0), (x: 2.0, y: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -350,7 +350,7 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -360,7 +360,7 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))]
 
         input.append((x: 1.0, y: 1.0, m: 1.0))
@@ -372,8 +372,8 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = LineString<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LineString<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
+        var input2 = LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -382,7 +382,7 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
 
         input.append(contentsOf: expected)
@@ -394,8 +394,8 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [(x: 1.0, y: 1.0, m: 1.0), (x: 2.0, y: 2.0, m: 2.0)])
 
@@ -404,7 +404,7 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
 
         input.insert(Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), at: 0)
@@ -416,7 +416,7 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
 
         input.insert((x: 2.0, y: 2.0, m: 2.0), at: 0)
@@ -428,8 +428,8 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -438,8 +438,8 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -448,8 +448,8 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -458,7 +458,7 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -470,14 +470,14 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = LineString<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)))
     }
 
     func testSubscript_Set() {
 
-        var input = LineString<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
 
         input[1] = Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))
 
@@ -486,29 +486,29 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs).equals(LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs).equals(LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -521,7 +521,7 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -537,13 +537,13 @@ class LineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(LineString<Coordinate3D>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -553,12 +553,12 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(LineString<Coordinate3D>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(LineString<Coordinate3D>(coordinateSystem: cs).coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = LineString<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
 
         XCTAssertTrue(
@@ -570,8 +570,8 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = LineString<Coordinate3D>(other: LineString<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3D>(other: LineString<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)]), precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
@@ -584,7 +584,7 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "LineString<Coordinate3D>((x: 1.0, y: 1.0, z: 1.0), (x: 2.0, y: 2.0, z: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -592,7 +592,7 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "LineString<Coordinate3D>((x: 1.0, y: 1.0, z: 1.0), (x: 2.0, y: 2.0, z: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -602,7 +602,7 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -612,7 +612,7 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))]
 
         input.append((x: 1.0, y: 1.0, z: 1.0))
@@ -624,8 +624,8 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = LineString<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LineString<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateSystem: cs)
+        var input2 = LineString<Coordinate3D>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -634,7 +634,7 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
 
         input.append(contentsOf: expected)
@@ -646,8 +646,8 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [(x: 1.0, y: 1.0, z: 1.0), (x: 2.0, y: 2.0, z: 2.0)])
 
@@ -656,7 +656,7 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
 
         input.insert(Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), at: 0)
@@ -668,7 +668,7 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
 
         input.insert((x: 2.0, y: 2.0, z: 2.0), at: 0)
@@ -680,8 +680,8 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -690,8 +690,8 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -700,8 +700,8 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3D>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -710,7 +710,7 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -722,14 +722,14 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = LineString<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)))
     }
 
     func testSubscript_Set() {
 
-        var input = LineString<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateSystem: cs)
 
         input[1] = Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))
 
@@ -738,29 +738,29 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs).equals(LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs).equals(LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(LineString<Coordinate3D>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -773,7 +773,7 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -789,13 +789,13 @@ class LineString_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -805,12 +805,12 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(LineString<Coordinate3DM>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(LineString<Coordinate3DM>(coordinateSystem: cs).coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = LineString<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         XCTAssertTrue(
@@ -822,8 +822,8 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = LineString<Coordinate3DM>(other: LineString<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3DM>(other: LineString<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)]), precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
@@ -836,7 +836,7 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "LineString<Coordinate3DM>((x: 1.0, y: 1.0, z: 1.0, m: 1.0), (x: 2.0, y: 2.0, z: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -844,7 +844,7 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "LineString<Coordinate3DM>((x: 1.0, y: 1.0, z: 1.0, m: 1.0), (x: 2.0, y: 2.0, z: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -854,7 +854,7 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -864,7 +864,7 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))]
 
         input.append((x: 1.0, y: 1.0, z: 1.0, m: 1.0))
@@ -876,8 +876,8 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = LineString<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LineString<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
+        var input2 = LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -886,7 +886,7 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         input.append(contentsOf: expected)
@@ -898,8 +898,8 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0), (x: 2.0, y: 2.0, z: 2.0, m: 2.0)])
 
@@ -908,7 +908,7 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         input.insert(Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), at: 0)
@@ -920,7 +920,7 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         input.insert((x: 2.0, y: 2.0, z: 2.0, m: 2.0), at: 0)
@@ -932,8 +932,8 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -942,8 +942,8 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -952,8 +952,8 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -962,7 +962,7 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -974,14 +974,14 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = LineString<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)))
     }
 
     func testSubscript_Set() {
 
-        var input = LineString<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
 
         input[1] = Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))
 
@@ -990,29 +990,29 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs).equals(LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs).equals(LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -1025,7 +1025,7 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -1041,13 +1041,13 @@ class LineString_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(LineString<Coordinate2D>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -1057,12 +1057,12 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(LineString<Coordinate2D>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(LineString<Coordinate2D>(coordinateSystem: cs).coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = LineString<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
 
         XCTAssertTrue(
@@ -1074,8 +1074,8 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = LineString<Coordinate2D>(other: LineString<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2D>(other: LineString<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)]), precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
@@ -1088,7 +1088,7 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "LineString<Coordinate2D>((x: 1.0, y: 1.0), (x: 2.0, y: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -1096,7 +1096,7 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "LineString<Coordinate2D>((x: 1.0, y: 1.0), (x: 2.0, y: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -1106,7 +1106,7 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -1116,7 +1116,7 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0))]
 
         input.append((x: 1.001, y: 1.001))
@@ -1128,8 +1128,8 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = LineString<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LineString<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateSystem: cs)
+        var input2 = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -1138,7 +1138,7 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
 
         input.append(contentsOf: expected)
@@ -1150,8 +1150,8 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)])
 
@@ -1160,7 +1160,7 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 2.0, y: 2.0)), Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
 
         input.insert(Coordinate2D(tuple: (x: 2.002, y: 2.002)), at: 0)
@@ -1172,7 +1172,7 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 2.0, y: 2.0)), Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
 
         input.insert((x: 2.002, y: 2.002), at: 0)
@@ -1184,8 +1184,8 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -1194,8 +1194,8 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -1204,8 +1204,8 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -1214,7 +1214,7 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -1226,14 +1226,14 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = LineString<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], Coordinate2D(tuple: (x: 2.0, y: 2.0)))
     }
 
     func testSubscript_Set() {
 
-        var input = LineString<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateSystem: cs)
 
         input[1] = Coordinate2D(tuple: (x: 1.001, y: 1.001))
 
@@ -1242,29 +1242,29 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs).equals(LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs).equals(LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(LineString<Coordinate2D>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(LineString<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -1277,7 +1277,7 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = LineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -1293,13 +1293,13 @@ class LineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -1309,12 +1309,12 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(LineString<Coordinate2DM>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(LineString<Coordinate2DM>(coordinateSystem: cs).coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = LineString<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
 
         XCTAssertTrue(
@@ -1326,8 +1326,8 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = LineString<Coordinate2DM>(other: LineString<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2DM>(other: LineString<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)]), precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
@@ -1340,7 +1340,7 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "LineString<Coordinate2DM>((x: 1.0, y: 1.0, m: 1.0), (x: 2.0, y: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -1348,7 +1348,7 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "LineString<Coordinate2DM>((x: 1.0, y: 1.0, m: 1.0), (x: 2.0, y: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -1358,7 +1358,7 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -1368,7 +1368,7 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))]
 
         input.append((x: 1.001, y: 1.001, m: 1.001))
@@ -1380,8 +1380,8 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = LineString<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LineString<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateSystem: cs)
+        var input2 = LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -1390,7 +1390,7 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
 
         input.append(contentsOf: expected)
@@ -1402,8 +1402,8 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [(x: 1.0, y: 1.0, m: 1.0), (x: 2.0, y: 2.0, m: 2.0)])
 
@@ -1412,7 +1412,7 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
 
         input.insert(Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002)), at: 0)
@@ -1424,7 +1424,7 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
 
         input.insert((x: 2.002, y: 2.002, m: 2.002), at: 0)
@@ -1436,8 +1436,8 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -1446,8 +1446,8 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -1456,8 +1456,8 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -1466,7 +1466,7 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -1478,14 +1478,14 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = LineString<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)))
     }
 
     func testSubscript_Set() {
 
-        var input = LineString<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateSystem: cs)
 
         input[1] = Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001))
 
@@ -1494,29 +1494,29 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs).equals(LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs).equals(LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(LineString<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -1529,7 +1529,7 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = LineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -1545,13 +1545,13 @@ class LineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(LineString<Coordinate3D>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -1561,12 +1561,12 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(LineString<Coordinate3D>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(LineString<Coordinate3D>(coordinateSystem: cs).coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = LineString<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
 
         XCTAssertTrue(
@@ -1578,8 +1578,8 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = LineString<Coordinate3D>(other: LineString<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3D>(other: LineString<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)]), precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
@@ -1592,7 +1592,7 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "LineString<Coordinate3D>((x: 1.0, y: 1.0, z: 1.0), (x: 2.0, y: 2.0, z: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -1600,7 +1600,7 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "LineString<Coordinate3D>((x: 1.0, y: 1.0, z: 1.0), (x: 2.0, y: 2.0, z: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -1610,7 +1610,7 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -1620,7 +1620,7 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))]
 
         input.append((x: 1.001, y: 1.001, z: 1.001))
@@ -1632,8 +1632,8 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = LineString<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LineString<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateSystem: cs)
+        var input2 = LineString<Coordinate3D>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -1642,7 +1642,7 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
 
         input.append(contentsOf: expected)
@@ -1654,8 +1654,8 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [(x: 1.0, y: 1.0, z: 1.0), (x: 2.0, y: 2.0, z: 2.0)])
 
@@ -1664,7 +1664,7 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
 
         input.insert(Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002)), at: 0)
@@ -1676,7 +1676,7 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
 
         input.insert((x: 2.002, y: 2.002, z: 2.002), at: 0)
@@ -1688,8 +1688,8 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -1698,8 +1698,8 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -1708,8 +1708,8 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3D>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -1718,7 +1718,7 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -1730,14 +1730,14 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = LineString<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)))
     }
 
     func testSubscript_Set() {
 
-        var input = LineString<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateSystem: cs)
 
         input[1] = Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001))
 
@@ -1746,29 +1746,29 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs).equals(LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs).equals(LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(LineString<Coordinate3D>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(LineString<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -1781,7 +1781,7 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = LineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -1797,13 +1797,13 @@ class LineString_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -1813,12 +1813,12 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(LineString<Coordinate3DM>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(LineString<Coordinate3DM>(coordinateSystem: cs).coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = LineString<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         XCTAssertTrue(
@@ -1830,8 +1830,8 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = LineString<Coordinate3DM>(other: LineString<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3DM>(other: LineString<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)]), precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
@@ -1844,7 +1844,7 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "LineString<Coordinate3DM>((x: 1.0, y: 1.0, z: 1.0, m: 1.0), (x: 2.0, y: 2.0, z: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -1852,7 +1852,7 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "LineString<Coordinate3DM>((x: 1.0, y: 1.0, z: 1.0, m: 1.0), (x: 2.0, y: 2.0, z: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -1862,7 +1862,7 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -1872,7 +1872,7 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))]
 
         input.append((x: 1.001, y: 1.001, z: 1.001, m: 1.001))
@@ -1884,8 +1884,8 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = LineString<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LineString<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateSystem: cs)
+        var input2 = LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -1894,7 +1894,7 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         input.append(contentsOf: expected)
@@ -1906,8 +1906,8 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0), (x: 2.0, y: 2.0, z: 2.0, m: 2.0)])
 
@@ -1916,7 +1916,7 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         input.insert(Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002)), at: 0)
@@ -1928,7 +1928,7 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         input.insert((x: 2.002, y: 2.002, z: 2.002, m: 2.002), at: 0)
@@ -1940,8 +1940,8 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -1950,8 +1950,8 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -1960,8 +1960,8 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -1970,7 +1970,7 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -1982,14 +1982,14 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = LineString<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LineString<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)))
     }
 
     func testSubscript_Set() {
 
-        var input = LineString<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateSystem: cs)
 
         input[1] = Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001))
 
@@ -1998,29 +1998,29 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs).equals(LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs).equals(LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(LineString<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -2033,7 +2033,7 @@ class LineString_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = LineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LineString<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity

--- a/Tests/GeoFeaturesTests/LinearRing+CurveTests.swift
+++ b/Tests/GeoFeaturesTests/LinearRing+CurveTests.swift
@@ -25,26 +25,26 @@ import GeoFeatures
 class LinearRing_Curve_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testLength_Test1() {
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 1, y: 1)], precision: precision, coordinateReferenceSystem: crs).length(), 1.4142135623730951)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 1, y: 1)], precision: precision, coordinateSystem: cs).length(), 1.4142135623730951)
     }
 
     func testLength_Test2() {
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2)], precision: precision, coordinateReferenceSystem: crs).length(), 2.0)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2)], precision: precision, coordinateSystem: cs).length(), 2.0)
     }
 
     func testLength_Test3() {
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 7, y:0)], precision: precision, coordinateReferenceSystem: crs).length(), 7.0)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 7, y:0)], precision: precision, coordinateSystem: cs).length(), 7.0)
     }
 
     func testLength_Test4() {
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 0, y: 4), (x: 0, y: 5)], precision: precision, coordinateReferenceSystem: crs).length(), 5.0)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 0, y: 4), (x: 0, y: 5)], precision: precision, coordinateSystem: cs).length(), 5.0)
     }
 
     func testLengthPerformance() {
-        let lineString = LinearRing<Coordinate2D>(elements: [(x:0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 0, y: 4), (x: 0, y: 5)], precision: precision, coordinateReferenceSystem: crs)
+        let lineString = LinearRing<Coordinate2D>(elements: [(x:0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 0, y: 4), (x: 0, y: 5)], precision: precision, coordinateSystem: cs)
 
         self.measure {
 
@@ -55,15 +55,15 @@ class LinearRing_Curve_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCas
     }
 
     func testIsClosed_Closed() {
-        XCTAssertTrue(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 2, y: 0), (x: 0, y: 0)], precision: precision, coordinateReferenceSystem: crs).isClosed())
+        XCTAssertTrue(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 2, y: 0), (x: 0, y: 0)], precision: precision, coordinateSystem: cs).isClosed())
     }
 
     func testIsClosed_Open() {
-        XCTAssertFalse(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 0, y: 4), (x: 0, y: 5)], precision: precision, coordinateReferenceSystem: crs).isClosed())
+        XCTAssertFalse(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 0, y: 4), (x: 0, y: 5)], precision: precision, coordinateSystem: cs).isClosed())
     }
 
     func testIsClosed_Empty() {
-        XCTAssertFalse(LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).isClosed())
+        XCTAssertFalse(LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs).isClosed())
     }
 }
 
@@ -72,10 +72,10 @@ class LinearRing_Curve_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCas
 class LinearRing_Curve_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testPerformanceLength() {
-        let lineString = LinearRing<Coordinate3D>(elements: [(x:0, y: 0, z: 0), (x: 0, y: 2, z: 0), (x: 0, y: 3, z: 0), (x: 0, y: 4, z: 0), (x: 0, y: 5, z:0)], precision: precision, coordinateReferenceSystem: crs)
+        let lineString = LinearRing<Coordinate3D>(elements: [(x:0, y: 0, z: 0), (x: 0, y: 2, z: 0), (x: 0, y: 3, z: 0), (x: 0, y: 4, z: 0), (x: 0, y: 5, z:0)], precision: precision, coordinateSystem: cs)
 
         self.measure {
 

--- a/Tests/GeoFeaturesTests/LinearRing+GeometryTests.swift
+++ b/Tests/GeoFeaturesTests/LinearRing+GeometryTests.swift
@@ -27,57 +27,57 @@ private let geometryDimension = Dimension.one    // LinearRing are always 1 dime
 class LinearRing_Geometry_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testBoundary_1Element_Invalid() {
-        let geometry = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0)], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs) // Empty Set
+        let geometry = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0)], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs) // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_2Element() {
-        let geometry = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let geometry = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_3Element_Open() {
-        let geometry = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0), (x: 3.0, y: 3.0)], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 3.0, y: 3.0))], precision: precision, coordinateReferenceSystem: crs)
+        let geometry = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0), (x: 3.0, y: 3.0)], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 3.0, y: 3.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_4Element_Closed() {
-        let geometry = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0), (x: 3.0, y: 3.0), (x: 1.0, y: 1.0)], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs) // Empty Set
+        let geometry = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0), (x: 3.0, y: 3.0), (x: 1.0, y: 1.0)], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs) // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_Empty() {
-        let geometry = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testEqual_True() {
-        let input1 = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
-        let input2 = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
+        let input2 = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input1, input2)
      }
 
      func testEqual_False() {
-        let input1            = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
-        let input2: Geometry  = Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0), precision: precision, coordinateReferenceSystem: crs)
+        let input1            = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
+        let input2: Geometry  = Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0), precision: precision, coordinateSystem: cs)
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
      }
@@ -88,10 +88,10 @@ class LinearRing_Geometry_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTest
 class LinearRing_Geometry_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -100,10 +100,10 @@ class LinearRing_Geometry_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTes
 class LinearRing_Geometry_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -112,10 +112,10 @@ class LinearRing_Geometry_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTest
 class LinearRing_Geometry_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -124,10 +124,10 @@ class LinearRing_Geometry_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTes
 class LinearRing_Geometry_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -136,10 +136,10 @@ class LinearRing_Geometry_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCas
 class LinearRing_Geometry_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -148,10 +148,10 @@ class LinearRing_Geometry_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCa
 class LinearRing_Geometry_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -160,9 +160,9 @@ class LinearRing_Geometry_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCas
 class LinearRing_Geometry_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }

--- a/Tests/GeoFeaturesTests/LinearRing+SurfaceTests.swift
+++ b/Tests/GeoFeaturesTests/LinearRing+SurfaceTests.swift
@@ -26,59 +26,59 @@ import GeoFeatures
 class LinearRing_Surface_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
     let accuracy  = 0.000000000001
 
     func testArea_Empty() {
-        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).area(), 0.0, accuracy: accuracy)
+        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs).area(), 0.0, accuracy: accuracy)
     }
 
     func testArea_Triangle() {
-        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 2.96, y: 5.15), (x: 9.33, y: 7.62), (x: 8.29, y: 0.88)], precision: precision, coordinateReferenceSystem: crs).area(), 20.1825, accuracy: accuracy)
+        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 2.96, y: 5.15), (x: 9.33, y: 7.62), (x: 8.29, y: 0.88)], precision: precision, coordinateSystem: cs).area(), 20.1825, accuracy: accuracy)
     }
 
     func testArea_RegularQuadrilateral() {
-        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 3.18, y: 3.12), (x: 5.43, y: 8.22), (x: 10.53, y: 5.98), (x: 8.29, y: 0.88)], precision: precision, coordinateReferenceSystem: crs).area(), 31.0643, accuracy: accuracy)
+        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 3.18, y: 3.12), (x: 5.43, y: 8.22), (x: 10.53, y: 5.98), (x: 8.29, y: 0.88)], precision: precision, coordinateSystem: cs).area(), 31.0643, accuracy: accuracy)
     }
 
     func testArea_SimplePolygon1() {
-        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 0.72, y: 2.28), (x: 2.66, y: 4.71), (x: 5.0, y: 3.5), (x: 3.63, y: 2.52), (x: 4.0, y: 1.6), (x: 1.9, y: 1.0), (x: 0.72, y: 2.28)], precision: precision, coordinateReferenceSystem: crs).area(), 8.3593, accuracy: accuracy)
+        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 0.72, y: 2.28), (x: 2.66, y: 4.71), (x: 5.0, y: 3.5), (x: 3.63, y: 2.52), (x: 4.0, y: 1.6), (x: 1.9, y: 1.0), (x: 0.72, y: 2.28)], precision: precision, coordinateSystem: cs).area(), 8.3593, accuracy: accuracy)
     }
 
     func testArea_SimplePolygon2() {
-        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 7), (x: 4, y: 2), (x: 2, y: 0), (x: 0, y: 0)], precision: precision, coordinateReferenceSystem: crs).area(), 16.0, accuracy: accuracy)
+        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 7), (x: 4, y: 2), (x: 2, y: 0), (x: 0, y: 0)], precision: precision, coordinateSystem: cs).area(), 16.0, accuracy: accuracy)
     }
 
     func testArea_SimplePolygon3() {
-        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 6), (x: 6, y: 6), (x: 6, y: 0), (x: 0, y: 0)], precision: precision, coordinateReferenceSystem: crs).area(), 36.0, accuracy: accuracy)
+        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 6), (x: 6, y: 6), (x: 6, y: 0), (x: 0, y: 0)], precision: precision, coordinateSystem: cs).area(), 36.0, accuracy: accuracy)
     }
 
     func testArea_SimplePolygon4() {
-        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 1, y: 1), (x: 4, y: 1), (x: 4, y: 2), (x: 1, y: 2), (x: 1, y: 1)], precision: precision, coordinateReferenceSystem: crs).area(), -3.0, accuracy: accuracy)
+        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 1, y: 1), (x: 4, y: 1), (x: 4, y: 2), (x: 1, y: 2), (x: 1, y: 1)], precision: precision, coordinateSystem: cs).area(), -3.0, accuracy: accuracy)
     }
 
     func testArea_Pentagon() {
-        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 7.61, y: 4.86), (x: 1.53, y: 3.60), (x: 7.86, y: 8.36), (x: 10.79, y: 4.77), (x: 8.29, y: 0.88)], precision: precision, coordinateReferenceSystem: crs).area(), 22.35635, accuracy: accuracy)
+        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 7.61, y: 4.86), (x: 1.53, y: 3.60), (x: 7.86, y: 8.36), (x: 10.79, y: 4.77), (x: 8.29, y: 0.88)], precision: precision, coordinateSystem: cs).area(), 22.35635, accuracy: accuracy)
     }
 
     func testArea_RegularPentagon() {
-        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 3.81, y: 2.06), (x: 3.54, y: 6.68), (x: 7.86, y: 8.36), (x: 10.79, y: 4.77), (x: 8.29, y: 0.88)], precision: precision, coordinateReferenceSystem: crs).area(), 36.89385, accuracy: accuracy)
+        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 3.81, y: 2.06), (x: 3.54, y: 6.68), (x: 7.86, y: 8.36), (x: 10.79, y: 4.77), (x: 8.29, y: 0.88)], precision: precision, coordinateSystem: cs).area(), 36.89385, accuracy: accuracy)
     }
 
     func testArea_RegularDecagon() {
-        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 5.85, y: 0.74), (x: 3.81, y: 2.06), (x: 2.92, y: 4.33), (x: 3.54, y: 6.68), (x: 5.43, y: 8.22), (x: 7.86, y: 8.36), (x: 9.91, y: 7.04), (x: 10.79, y: 4.77), (x: 10.17, y: 2.42), (x: 8.29, y: 0.88)], precision: precision, coordinateReferenceSystem: crs).area(), 45.61285, accuracy: accuracy)
+        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 5.85, y: 0.74), (x: 3.81, y: 2.06), (x: 2.92, y: 4.33), (x: 3.54, y: 6.68), (x: 5.43, y: 8.22), (x: 7.86, y: 8.36), (x: 9.91, y: 7.04), (x: 10.79, y: 4.77), (x: 10.17, y: 2.42), (x: 8.29, y: 0.88)], precision: precision, coordinateSystem: cs).area(), 45.61285, accuracy: accuracy)
     }
 
     func testArea_Tetrakaidecagon() {
-        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 8.32, y: 1.66), (x: 6.55, y: 0.62), (x: 4.88, y: 1.14), (x: 8.32, y: 2.95), (x: 2.96, y: 3.98), (x: 7.04, y: 6.15), (x: 7.24, y: 7.20), (x: 5.43, y: 8.22), (x: 7.17, y: 8.48), (x: 8.84, y: 7.96), (x: 6.65, y: 4.32), (x: 10.76, y: 5.12), (x: 8.87, y: 4.06), (x: 9.74, y: 1.86), (x: 8.32, y: 1.66)], precision: precision, coordinateReferenceSystem: crs).area(), 18.63, accuracy: accuracy)
+        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 8.32, y: 1.66), (x: 6.55, y: 0.62), (x: 4.88, y: 1.14), (x: 8.32, y: 2.95), (x: 2.96, y: 3.98), (x: 7.04, y: 6.15), (x: 7.24, y: 7.20), (x: 5.43, y: 8.22), (x: 7.17, y: 8.48), (x: 8.84, y: 7.96), (x: 6.65, y: 4.32), (x: 10.76, y: 5.12), (x: 8.87, y: 4.06), (x: 9.74, y: 1.86), (x: 8.32, y: 1.66)], precision: precision, coordinateSystem: cs).area(), 18.63, accuracy: accuracy)
     }
 
     func testArea_Quadrilateral_CrossingOrigin () {
-        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 1.00, y: -1.00), (x: -1.00, y: -1.00), (x: -1.00, y: 1.00), (x: 1.00, y: 1.00), (x: 1.00, y: -1.00)], precision: precision, coordinateReferenceSystem: crs).area(), 4.0, accuracy: accuracy)
+        XCTAssertEqualWithAccuracy(LinearRing<Coordinate2D>(elements: [(x: 1.00, y: -1.00), (x: -1.00, y: -1.00), (x: -1.00, y: 1.00), (x: 1.00, y: 1.00), (x: 1.00, y: -1.00)], precision: precision, coordinateSystem: cs).area(), 4.0, accuracy: accuracy)
     }
 
     func testPerformanceArea_RegularQuadrilateral() {
-        let geometry = LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 3.18, y: 3.12), (x: 5.43, y: 8.22), (x: 10.53, y: 5.98), (x: 8.29, y: 0.88)], precision: precision, coordinateReferenceSystem: crs)
+        let geometry = LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 3.18, y: 3.12), (x: 5.43, y: 8.22), (x: 10.53, y: 5.98), (x: 8.29, y: 0.88)], precision: precision, coordinateSystem: cs)
 
         self.measure {
 
@@ -94,58 +94,58 @@ class LinearRing_Surface_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestC
 class LinearRing_Surface_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100000)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testArea_Empty() {
-        XCTAssertEqual(LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).area(), 0.0)
+        XCTAssertEqual(LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs).area(), 0.0)
     }
 
     func testArea_Triangle() {
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 2.96, y: 5.15), (x: 9.33, y: 7.62), (x: 8.29, y: 0.88)], precision: precision, coordinateReferenceSystem: crs).area(), 20.1825)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 2.96, y: 5.15), (x: 9.33, y: 7.62), (x: 8.29, y: 0.88)], precision: precision, coordinateSystem: cs).area(), 20.1825)
     }
 
     func testArea_RegularQuadrilateral() {
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 3.18, y: 3.12), (x: 5.43, y: 8.22), (x: 10.53, y: 5.98), (x: 8.29, y: 0.88)], precision: precision, coordinateReferenceSystem: crs).area(), 31.0643)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 3.18, y: 3.12), (x: 5.43, y: 8.22), (x: 10.53, y: 5.98), (x: 8.29, y: 0.88)], precision: precision, coordinateSystem: cs).area(), 31.0643)
     }
 
     func testArea_SimplePolygon1() {
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 0.72, y: 2.28), (x: 2.66, y: 4.71), (x: 5.0, y: 3.5), (x: 3.63, y: 2.52), (x: 4.0, y: 1.6), (x: 1.9, y: 1.0), (x: 0.72, y: 2.28)], precision: precision, coordinateReferenceSystem: crs).area(), 8.3593)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 0.72, y: 2.28), (x: 2.66, y: 4.71), (x: 5.0, y: 3.5), (x: 3.63, y: 2.52), (x: 4.0, y: 1.6), (x: 1.9, y: 1.0), (x: 0.72, y: 2.28)], precision: precision, coordinateSystem: cs).area(), 8.3593)
     }
 
     func testArea_SimplePolygon2() {
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 7), (x: 4, y: 2), (x: 2, y: 0), (x: 0, y: 0)], precision: precision, coordinateReferenceSystem: crs).area(), 16.0)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 7), (x: 4, y: 2), (x: 2, y: 0), (x: 0, y: 0)], precision: precision, coordinateSystem: cs).area(), 16.0)
     }
 
     func testArea_SimplePolygon3() {
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 6), (x: 6, y: 6), (x: 6, y: 0), (x: 0, y: 0)], precision: precision, coordinateReferenceSystem: crs).area(), 36.0)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 6), (x: 6, y: 6), (x: 6, y: 0), (x: 0, y: 0)], precision: precision, coordinateSystem: cs).area(), 36.0)
     }
 
     func testArea_SimplePolygon4() {
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 1, y: 1), (x: 4, y: 1), (x: 4, y: 2), (x: 1, y: 2), (x: 1, y: 1)], precision: precision, coordinateReferenceSystem: crs).area(), -3.0)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 1, y: 1), (x: 4, y: 1), (x: 4, y: 2), (x: 1, y: 2), (x: 1, y: 1)], precision: precision, coordinateSystem: cs).area(), -3.0)
     }
 
     func testArea_Pentagon() {
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 7.61, y: 4.86), (x: 1.53, y: 3.60), (x: 7.86, y: 8.36), (x: 10.79, y: 4.77), (x: 8.29, y: 0.88)], precision: precision, coordinateReferenceSystem: crs).area(), 22.35635)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 7.61, y: 4.86), (x: 1.53, y: 3.60), (x: 7.86, y: 8.36), (x: 10.79, y: 4.77), (x: 8.29, y: 0.88)], precision: precision, coordinateSystem: cs).area(), 22.35635)
     }
 
     func testArea_RegularPentagon() {
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 3.81, y: 2.06), (x: 3.54, y: 6.68), (x: 7.86, y: 8.36), (x: 10.79, y: 4.77), (x: 8.29, y: 0.88)], precision: precision, coordinateReferenceSystem: crs).area(), 36.89385)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 3.81, y: 2.06), (x: 3.54, y: 6.68), (x: 7.86, y: 8.36), (x: 10.79, y: 4.77), (x: 8.29, y: 0.88)], precision: precision, coordinateSystem: cs).area(), 36.89385)
     }
 
     func testArea_RegularDecagon() {
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 5.85, y: 0.74), (x: 3.81, y: 2.06), (x: 2.92, y: 4.33), (x: 3.54, y: 6.68), (x: 5.43, y: 8.22), (x: 7.86, y: 8.36), (x: 9.91, y: 7.04), (x: 10.79, y: 4.77), (x: 10.17, y: 2.42), (x: 8.29, y: 0.88)], precision: precision, coordinateReferenceSystem: crs).area(), 45.61285)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 5.85, y: 0.74), (x: 3.81, y: 2.06), (x: 2.92, y: 4.33), (x: 3.54, y: 6.68), (x: 5.43, y: 8.22), (x: 7.86, y: 8.36), (x: 9.91, y: 7.04), (x: 10.79, y: 4.77), (x: 10.17, y: 2.42), (x: 8.29, y: 0.88)], precision: precision, coordinateSystem: cs).area(), 45.61285)
     }
 
     func testArea_Tetrakaidecagon() {
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 8.32, y: 1.66), (x: 6.55, y: 0.62), (x: 4.88, y: 1.14), (x: 8.32, y: 2.95), (x: 2.96, y: 3.98), (x: 7.04, y: 6.15), (x: 7.24, y: 7.20), (x: 5.43, y: 8.22), (x: 7.17, y: 8.48), (x: 8.84, y: 7.96), (x: 6.65, y: 4.32), (x: 10.76, y: 5.12), (x: 8.87, y: 4.06), (x: 9.74, y: 1.86), (x: 8.32, y: 1.66)], precision: precision, coordinateReferenceSystem: crs).area(), 18.63)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 8.32, y: 1.66), (x: 6.55, y: 0.62), (x: 4.88, y: 1.14), (x: 8.32, y: 2.95), (x: 2.96, y: 3.98), (x: 7.04, y: 6.15), (x: 7.24, y: 7.20), (x: 5.43, y: 8.22), (x: 7.17, y: 8.48), (x: 8.84, y: 7.96), (x: 6.65, y: 4.32), (x: 10.76, y: 5.12), (x: 8.87, y: 4.06), (x: 9.74, y: 1.86), (x: 8.32, y: 1.66)], precision: precision, coordinateSystem: cs).area(), 18.63)
     }
 
     func testArea_Quadrilateral_CrossingOrigin () {
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 1.00, y: -1.00), (x: -1.00, y: -1.00), (x: -1.00, y: 1.00), (x: 1.00, y: 1.00), (x: 1.00, y: -1.00)], precision: precision, coordinateReferenceSystem: crs).area(), 4.0)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [(x: 1.00, y: -1.00), (x: -1.00, y: -1.00), (x: -1.00, y: 1.00), (x: 1.00, y: 1.00), (x: 1.00, y: -1.00)], precision: precision, coordinateSystem: cs).area(), 4.0)
     }
 
     func testPerformanceArea_RegularQuadrilateral() {
-        let geometry = LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 3.18, y: 3.12), (x: 5.43, y: 8.22), (x: 10.53, y: 5.98), (x: 8.29, y: 0.88)], precision: precision, coordinateReferenceSystem: crs)
+        let geometry = LinearRing<Coordinate2D>(elements: [(x: 8.29, y: 0.88), (x: 3.18, y: 3.12), (x: 5.43, y: 8.22), (x: 10.53, y: 5.98), (x: 8.29, y: 0.88)], precision: precision, coordinateSystem: cs)
 
         self.measure {
 

--- a/Tests/GeoFeaturesTests/LinearRingTests.swift
+++ b/Tests/GeoFeaturesTests/LinearRingTests.swift
@@ -33,13 +33,13 @@ import GeoFeatures
 class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -49,12 +49,12 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(LinearRing<Coordinate2D>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(LinearRing<Coordinate2D>(coordinateSystem: cs).coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
 
         XCTAssertTrue(
@@ -66,8 +66,8 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = LinearRing<Coordinate2D>(other: LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2D>(other: LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)]), precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
@@ -80,7 +80,7 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "LinearRing<Coordinate2D>((x: 1.0, y: 1.0), (x: 2.0, y: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -88,7 +88,7 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "LinearRing<Coordinate2D>((x: 1.0, y: 1.0), (x: 2.0, y: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -98,7 +98,7 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -108,7 +108,7 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0))]
 
         input.append((x: 1.0, y: 1.0))
@@ -120,8 +120,8 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
+        var input2 = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -130,7 +130,7 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
 
         input.append(contentsOf: expected)
@@ -142,8 +142,8 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)])
 
@@ -152,7 +152,7 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 2.0, y: 2.0)), Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
 
         input.insert(Coordinate2D(tuple: (x: 2.0, y: 2.0)), at: 0)
@@ -164,7 +164,7 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 2.0, y: 2.0)), Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
 
         input.insert((x: 2.0, y: 2.0), at: 0)
@@ -176,8 +176,8 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -186,8 +186,8 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -196,8 +196,8 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -206,7 +206,7 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -218,14 +218,14 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], Coordinate2D(tuple: (x: 2.0, y: 2.0)))
     }
 
     func testSubscript_Set() {
 
-        var input = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
 
         input[1] = Coordinate2D(tuple: (x: 1.0, y: 1.0))
 
@@ -234,29 +234,29 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs).equals(LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs).equals(LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -269,7 +269,7 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -285,13 +285,13 @@ class LinearRing_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -301,12 +301,12 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(LinearRing<Coordinate2DM>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(LinearRing<Coordinate2DM>(coordinateSystem: cs).coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = LinearRing<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
 
         XCTAssertTrue(
@@ -318,8 +318,8 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = LinearRing<Coordinate2DM>(other: LinearRing<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2DM>(other: LinearRing<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)]), precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
@@ -332,7 +332,7 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "LinearRing<Coordinate2DM>((x: 1.0, y: 1.0, m: 1.0), (x: 2.0, y: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -340,7 +340,7 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "LinearRing<Coordinate2DM>((x: 1.0, y: 1.0, m: 1.0), (x: 2.0, y: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -350,7 +350,7 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -360,7 +360,7 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))]
 
         input.append((x: 1.0, y: 1.0, m: 1.0))
@@ -372,8 +372,8 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = LinearRing<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LinearRing<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
+        var input2 = LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -382,7 +382,7 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
 
         input.append(contentsOf: expected)
@@ -394,8 +394,8 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [(x: 1.0, y: 1.0, m: 1.0), (x: 2.0, y: 2.0, m: 2.0)])
 
@@ -404,7 +404,7 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
 
         input.insert(Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), at: 0)
@@ -416,7 +416,7 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
 
         input.insert((x: 2.0, y: 2.0, m: 2.0), at: 0)
@@ -428,8 +428,8 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -438,8 +438,8 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -448,8 +448,8 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -458,7 +458,7 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -470,14 +470,14 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = LinearRing<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)))
     }
 
     func testSubscript_Set() {
 
-        var input = LinearRing<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
 
         input[1] = Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))
 
@@ -486,29 +486,29 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs).equals(LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs).equals(LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -521,7 +521,7 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -537,13 +537,13 @@ class LinearRing_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -553,12 +553,12 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(LinearRing<Coordinate3D>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(LinearRing<Coordinate3D>(coordinateSystem: cs).coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = LinearRing<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
 
         XCTAssertTrue(
@@ -570,8 +570,8 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = LinearRing<Coordinate3D>(other: LinearRing<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3D>(other: LinearRing<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)]), precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
@@ -584,7 +584,7 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "LinearRing<Coordinate3D>((x: 1.0, y: 1.0, z: 1.0), (x: 2.0, y: 2.0, z: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -592,7 +592,7 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "LinearRing<Coordinate3D>((x: 1.0, y: 1.0, z: 1.0), (x: 2.0, y: 2.0, z: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -602,7 +602,7 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -612,7 +612,7 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))]
 
         input.append((x: 1.0, y: 1.0, z: 1.0))
@@ -624,8 +624,8 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = LinearRing<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LinearRing<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateSystem: cs)
+        var input2 = LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -634,7 +634,7 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
 
         input.append(contentsOf: expected)
@@ -646,8 +646,8 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [(x: 1.0, y: 1.0, z: 1.0), (x: 2.0, y: 2.0, z: 2.0)])
 
@@ -656,7 +656,7 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
 
         input.insert(Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), at: 0)
@@ -668,7 +668,7 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
 
         input.insert((x: 2.0, y: 2.0, z: 2.0), at: 0)
@@ -680,8 +680,8 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -690,8 +690,8 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -700,8 +700,8 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -710,7 +710,7 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -722,14 +722,14 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = LinearRing<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)))
     }
 
     func testSubscript_Set() {
 
-        var input = LinearRing<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateSystem: cs)
 
         input[1] = Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))
 
@@ -738,29 +738,29 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs).equals(LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs).equals(LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -773,7 +773,7 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -789,13 +789,13 @@ class LinearRing_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -805,12 +805,12 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(LinearRing<Coordinate3DM>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(LinearRing<Coordinate3DM>(coordinateSystem: cs).coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = LinearRing<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         XCTAssertTrue(
@@ -822,8 +822,8 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = LinearRing<Coordinate3DM>(other: LinearRing<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3DM>(other: LinearRing<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)]), precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
@@ -836,7 +836,7 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "LinearRing<Coordinate3DM>((x: 1.0, y: 1.0, z: 1.0, m: 1.0), (x: 2.0, y: 2.0, z: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -844,7 +844,7 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "LinearRing<Coordinate3DM>((x: 1.0, y: 1.0, z: 1.0, m: 1.0), (x: 2.0, y: 2.0, z: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -854,7 +854,7 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -864,7 +864,7 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))]
 
         input.append((x: 1.0, y: 1.0, z: 1.0, m: 1.0))
@@ -876,8 +876,8 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = LinearRing<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LinearRing<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
+        var input2 = LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -886,7 +886,7 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         input.append(contentsOf: expected)
@@ -898,8 +898,8 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0), (x: 2.0, y: 2.0, z: 2.0, m: 2.0)])
 
@@ -908,7 +908,7 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         input.insert(Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), at: 0)
@@ -920,7 +920,7 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         input.insert((x: 2.0, y: 2.0, z: 2.0, m: 2.0), at: 0)
@@ -932,8 +932,8 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -942,8 +942,8 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -952,8 +952,8 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -962,7 +962,7 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -974,14 +974,14 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = LinearRing<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)))
     }
 
     func testSubscript_Set() {
 
-        var input = LinearRing<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
 
         input[1] = Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))
 
@@ -990,29 +990,29 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs).equals(LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs).equals(LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -1025,7 +1025,7 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -1041,13 +1041,13 @@ class LinearRing_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -1057,12 +1057,12 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(LinearRing<Coordinate2D>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(LinearRing<Coordinate2D>(coordinateSystem: cs).coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = LinearRing<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
 
         XCTAssertTrue(
@@ -1074,8 +1074,8 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = LinearRing<Coordinate2D>(other: LinearRing<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2D>(other: LinearRing<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)]), precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2D>(elements: [(x: 1.0, y: 1.0),(x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: Coordinate2D, rhs: Coordinate2D) -> Bool in
@@ -1088,7 +1088,7 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "LinearRing<Coordinate2D>((x: 1.0, y: 1.0), (x: 2.0, y: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -1096,7 +1096,7 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "LinearRing<Coordinate2D>((x: 1.0, y: 1.0), (x: 2.0, y: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -1106,7 +1106,7 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -1116,7 +1116,7 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0))]
 
         input.append((x: 1.001, y: 1.001))
@@ -1128,8 +1128,8 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = LinearRing<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LinearRing<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateSystem: cs)
+        var input2 = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -1138,7 +1138,7 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
 
         input.append(contentsOf: expected)
@@ -1150,8 +1150,8 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)])
 
@@ -1160,7 +1160,7 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 2.0, y: 2.0)), Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
 
         input.insert(Coordinate2D(tuple: (x: 2.002, y: 2.002)), at: 0)
@@ -1172,7 +1172,7 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2D(tuple: (x: 2.0, y: 2.0)), Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))]
 
         input.insert((x: 2.002, y: 2.002), at: 0)
@@ -1184,8 +1184,8 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -1194,8 +1194,8 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -1204,8 +1204,8 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -1214,7 +1214,7 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -1226,14 +1226,14 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = LinearRing<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], Coordinate2D(tuple: (x: 2.0, y: 2.0)))
     }
 
     func testSubscript_Set() {
 
-        var input = LinearRing<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(elements: [(x: 1.001, y: 1.001),(x: 2.002, y: 2.002)], precision: precision, coordinateSystem: cs)
 
         input[1] = Coordinate2D(tuple: (x: 1.001, y: 1.001))
 
@@ -1242,29 +1242,29 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs).equals(LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs).equals(LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.0, y: 1.0)), Coordinate2D(tuple: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(LinearRing<Coordinate2D>(elements: [Coordinate2D(tuple: (x: 1.001, y: 1.001)), Coordinate2D(tuple: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -1277,7 +1277,7 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = LinearRing<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -1293,13 +1293,13 @@ class LinearRing_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -1309,12 +1309,12 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(LinearRing<Coordinate2DM>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(LinearRing<Coordinate2DM>(coordinateSystem: cs).coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = LinearRing<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
 
         XCTAssertTrue(
@@ -1326,8 +1326,8 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = LinearRing<Coordinate2DM>(other: LinearRing<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2DM>(other: LinearRing<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)]), precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2DM>(elements: [(x: 1.0, y: 1.0, m: 1.0),(x: 2.0, y: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: Coordinate2DM, rhs: Coordinate2DM) -> Bool in
@@ -1340,7 +1340,7 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "LinearRing<Coordinate2DM>((x: 1.0, y: 1.0, m: 1.0), (x: 2.0, y: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -1348,7 +1348,7 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "LinearRing<Coordinate2DM>((x: 1.0, y: 1.0, m: 1.0), (x: 2.0, y: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -1358,7 +1358,7 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -1368,7 +1368,7 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))]
 
         input.append((x: 1.001, y: 1.001, m: 1.001))
@@ -1380,8 +1380,8 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = LinearRing<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LinearRing<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateSystem: cs)
+        var input2 = LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -1390,7 +1390,7 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
 
         input.append(contentsOf: expected)
@@ -1402,8 +1402,8 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [(x: 1.0, y: 1.0, m: 1.0), (x: 2.0, y: 2.0, m: 2.0)])
 
@@ -1412,7 +1412,7 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
 
         input.insert(Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002)), at: 0)
@@ -1424,7 +1424,7 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)), Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))]
 
         input.insert((x: 2.002, y: 2.002, m: 2.002), at: 0)
@@ -1436,8 +1436,8 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -1446,8 +1446,8 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -1456,8 +1456,8 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -1466,7 +1466,7 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -1478,14 +1478,14 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = LinearRing<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0)))
     }
 
     func testSubscript_Set() {
 
-        var input = LinearRing<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(elements: [(x: 1.001, y: 1.001, m: 1.001),(x: 2.002, y: 2.002, m: 2.002)], precision: precision, coordinateSystem: cs)
 
         input[1] = Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001))
 
@@ -1494,29 +1494,29 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs).equals(LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs).equals(LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.0, y: 1.0, m: 1.0)), Coordinate2DM(tuple: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(LinearRing<Coordinate2DM>(elements: [Coordinate2DM(tuple: (x: 1.001, y: 1.001, m: 1.001)), Coordinate2DM(tuple: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -1529,7 +1529,7 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -1545,13 +1545,13 @@ class LinearRing_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -1561,12 +1561,12 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(LinearRing<Coordinate3D>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(LinearRing<Coordinate3D>(coordinateSystem: cs).coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = LinearRing<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
 
         XCTAssertTrue(
@@ -1578,8 +1578,8 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = LinearRing<Coordinate3D>(other: LinearRing<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3D>(other: LinearRing<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)]), precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3D>(elements: [(x: 1.0, y: 1.0, z: 1.0),(x: 2.0, y: 2.0, z: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: Coordinate3D, rhs: Coordinate3D) -> Bool in
@@ -1592,7 +1592,7 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "LinearRing<Coordinate3D>((x: 1.0, y: 1.0, z: 1.0), (x: 2.0, y: 2.0, z: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -1600,7 +1600,7 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "LinearRing<Coordinate3D>((x: 1.0, y: 1.0, z: 1.0), (x: 2.0, y: 2.0, z: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -1610,7 +1610,7 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -1620,7 +1620,7 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))]
 
         input.append((x: 1.001, y: 1.001, z: 1.001))
@@ -1632,8 +1632,8 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = LinearRing<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LinearRing<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateSystem: cs)
+        var input2 = LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -1642,7 +1642,7 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
 
         input.append(contentsOf: expected)
@@ -1654,8 +1654,8 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [(x: 1.0, y: 1.0, z: 1.0), (x: 2.0, y: 2.0, z: 2.0)])
 
@@ -1664,7 +1664,7 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
 
         input.insert(Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002)), at: 0)
@@ -1676,7 +1676,7 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)), Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))]
 
         input.insert((x: 2.002, y: 2.002, z: 2.002), at: 0)
@@ -1688,8 +1688,8 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -1698,8 +1698,8 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -1708,8 +1708,8 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -1718,7 +1718,7 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -1730,14 +1730,14 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = LinearRing<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0)))
     }
 
     func testSubscript_Set() {
 
-        var input = LinearRing<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(elements: [(x: 1.001, y: 1.001, z: 1.001),(x: 2.002, y: 2.002, z: 2.002)], precision: precision, coordinateSystem: cs)
 
         input[1] = Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001))
 
@@ -1746,29 +1746,29 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs).equals(LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs).equals(LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.0, y: 1.0, z: 1.0)), Coordinate3D(tuple: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(LinearRing<Coordinate3D>(elements: [Coordinate3D(tuple: (x: 1.001, y: 1.001, z: 1.001)), Coordinate3D(tuple: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -1781,7 +1781,7 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = LinearRing<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -1797,13 +1797,13 @@ class LinearRing_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
     func testInit_Precision_CRS() {
 
-        XCTAssertEqual(LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).isEmpty, true)
+        XCTAssertEqual(LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs).isEmpty, true)
     }
 
     func testInit_Precision() {
@@ -1813,12 +1813,12 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_CRS() {
 
-        XCTAssertEqual(LinearRing<Coordinate3DM>(coordinateReferenceSystem: crs).coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(LinearRing<Coordinate3DM>(coordinateSystem: cs).coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Tuple() {
 
-        let input = LinearRing<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         XCTAssertTrue(
@@ -1830,8 +1830,8 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Copy() {
 
-        let input = LinearRing<Coordinate3DM>(other: LinearRing<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3DM>(other: LinearRing<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)]), precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3DM>(elements: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0),(x: 2.0, y: 2.0, z: 2.0, m: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(
             (input.elementsEqual(expected) { (lhs: Coordinate3DM, rhs: Coordinate3DM) -> Bool in
@@ -1844,7 +1844,7 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "LinearRing<Coordinate3DM>((x: 1.0, y: 1.0, z: 1.0, m: 1.0), (x: 2.0, y: 2.0, z: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -1852,7 +1852,7 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "LinearRing<Coordinate3DM>((x: 1.0, y: 1.0, z: 1.0, m: 1.0), (x: 2.0, y: 2.0, z: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -1862,7 +1862,7 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -1872,7 +1872,7 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))]
 
         input.append((x: 1.001, y: 1.001, z: 1.001, m: 1.001))
@@ -1884,8 +1884,8 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = LinearRing<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = LinearRing<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateSystem: cs)
+        var input2 = LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -1894,7 +1894,7 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Coordinates() {
 
-        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         input.append(contentsOf: expected)
@@ -1906,8 +1906,8 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf_Tuples() {
 
-        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         input.append(contentsOf: [(x: 1.0, y: 1.0, z: 1.0, m: 1.0), (x: 2.0, y: 2.0, z: 2.0, m: 2.0)])
 
@@ -1916,7 +1916,7 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Coordinate() {
 
-        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         input.insert(Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002)), at: 0)
@@ -1928,7 +1928,7 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_Tuple() {
 
-        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         input.insert((x: 2.002, y: 2.002, z: 2.002, m: 2.002), at: 0)
@@ -1940,8 +1940,8 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -1950,8 +1950,8 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -1960,8 +1960,8 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -1970,7 +1970,7 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -1982,14 +1982,14 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input = LinearRing<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        let input = LinearRing<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input[1], Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)))
     }
 
     func testSubscript_Set() {
 
-        var input = LinearRing<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(elements: [(x: 1.001, y: 1.001, z: 1.001, m: 1.001),(x: 2.002, y: 2.002, z: 2.002, m: 2.002)], precision: precision, coordinateSystem: cs)
 
         input[1] = Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001))
 
@@ -1998,29 +1998,29 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        XCTAssertEqual(LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs).equals(LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)), true)
+        XCTAssertEqual(LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs).equals(LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Coordinate3DM(tuple: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)), true)
     }
 
     func testIsEmpty() {
 
-        XCTAssertEqual(LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).isEmpty(), true)
+        XCTAssertEqual(LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs).isEmpty(), true)
     }
 
     func testIsEmpty_False() {
 
-        XCTAssertEqual(LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testCount() {
 
-        XCTAssertEqual(LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs).count, 2)
+        XCTAssertEqual(LinearRing<Coordinate3DM>(elements: [Coordinate3DM(tuple: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Coordinate3DM(tuple: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs).count, 2)
     }
 
     // MARK: Misc Internal
 
     func testEnsureUniquelyReferenced() {
 
-        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -2033,7 +2033,7 @@ class LinearRing_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = LinearRing<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity

--- a/Tests/GeoFeaturesTests/MultiLineString+CurveTests.swift
+++ b/Tests/GeoFeaturesTests/MultiLineString+CurveTests.swift
@@ -25,30 +25,30 @@ import GeoFeatures
 class MultiLineString_Curve_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testIsClosed_Closed() {
         XCTAssertTrue(MultiLineString<Coordinate2D>(elements:
             [
-                LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 2, y: 0), (x: 0, y: 0)], precision: precision, coordinateReferenceSystem: crs),
-                LineString<Coordinate2D>(elements: [(x: 0, y: 1), (x: 0, y: 2), (x: 0, y: 3), (x: 2, y: 0), (x: 0, y: 1)], precision: precision, coordinateReferenceSystem: crs)
-            ], precision: precision, coordinateReferenceSystem: crs).isClosed())
+                LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 2, y: 0), (x: 0, y: 0)], precision: precision, coordinateSystem: cs),
+                LineString<Coordinate2D>(elements: [(x: 0, y: 1), (x: 0, y: 2), (x: 0, y: 3), (x: 2, y: 0), (x: 0, y: 1)], precision: precision, coordinateSystem: cs)
+            ], precision: precision, coordinateSystem: cs).isClosed())
     }
 
     func testIsClosed_Open() {
         XCTAssertFalse(MultiLineString<Coordinate2D>(elements:
             [
-                LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 0, y: 4), (x: 0, y: 5)], precision: precision, coordinateReferenceSystem: crs),
-                LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 0, y: 4), (x: 0, y: 5)], precision: precision, coordinateReferenceSystem: crs)
-            ], precision: precision, coordinateReferenceSystem: crs).isClosed())
+                LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 0, y: 4), (x: 0, y: 5)], precision: precision, coordinateSystem: cs),
+                LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2), (x: 0, y: 3), (x: 0, y: 4), (x: 0, y: 5)], precision: precision, coordinateSystem: cs)
+            ], precision: precision, coordinateSystem: cs).isClosed())
     }
 
     func testIsClosed_Empty() {
-        XCTAssertFalse(MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).isClosed())
+        XCTAssertFalse(MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs).isClosed())
     }
 
     func testLength_Test() {
-        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2)]), LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 7, y:0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 0, y: 2)]), LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 7, y:0)])], precision: precision, coordinateSystem: cs)
         let expected = 9.0
 
         XCTAssertEqual(input.length(), expected)
@@ -60,30 +60,30 @@ class MultiLineString_Curve_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTe
 class MultiLineString_Curve_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testIsClosed_Closed() {
         XCTAssertTrue(MultiLineString<Coordinate2D>(elements:
             [
-                LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)], precision: precision, coordinateReferenceSystem: crs),
-                LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)], precision: precision, coordinateReferenceSystem: crs)
-            ], precision: precision, coordinateReferenceSystem: crs).isClosed())
+                LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)], precision: precision, coordinateSystem: cs),
+                LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)], precision: precision, coordinateSystem: cs)
+            ], precision: precision, coordinateSystem: cs).isClosed())
     }
 
     func testIsClosed_Open() {
         XCTAssertFalse(MultiLineString<Coordinate2D>(elements:
             [
-                LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.003), (x: 0.0, y: 4.004), (x: 0.0, y: 5.001)], precision: precision, coordinateReferenceSystem: crs),
-                LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 0.0, y: 4.004), (x: 0.0, y: 5.001)], precision: precision, coordinateReferenceSystem: crs)
-            ], precision: precision, coordinateReferenceSystem: crs).isClosed())
+                LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.003), (x: 0.0, y: 4.004), (x: 0.0, y: 5.001)], precision: precision, coordinateSystem: cs),
+                LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 0.0, y: 4.004), (x: 0.0, y: 5.001)], precision: precision, coordinateSystem: cs)
+            ], precision: precision, coordinateSystem: cs).isClosed())
     }
 
     func testIsClosed_Empty() {
-        XCTAssertFalse(MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).isClosed())
+        XCTAssertFalse(MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs).isClosed())
     }
 
     func testLength_Test() {
-        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002)]), LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 7.001, y:0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002)]), LineString<Coordinate2D>(elements: [(x: 0, y: 0), (x: 7.001, y:0)])], precision: precision, coordinateSystem: cs)
         let expected = 9.0
 
         XCTAssertEqual(input.length(), expected)

--- a/Tests/GeoFeaturesTests/MultiLineString+GeometryTests.swift
+++ b/Tests/GeoFeaturesTests/MultiLineString+GeometryTests.swift
@@ -27,74 +27,74 @@ private let geometryDimension = Dimension.one    // MultiLineString are always 1
 class MultiLineString_Geometry_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testBoundary_1Element_Invalid() {
-        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs) // Empty Set
+        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0)])], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs) // Empty Set
 
         XCTAssertTrue(input == expected, "\(input) is not equal to \(expected)")
     }
 
     func testBoundary_2Element() {
-        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)])], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)])], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(input == expected, "\(input) is not equal to \(expected)")
     }
 
     func testBoundary_3Element_Open() {
-        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0), (x: 3.0, y: 3.0)])], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 3.0, y: 3.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0), (x: 3.0, y: 3.0)])], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 3.0, y: 3.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(input == expected, "\(input) is not equal to \(expected)")
     }
 
     func testBoundary_4Element_Closed() {
-        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0), (x: 3.0, y: 3.0), (x: 1.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs) // Empty Set
+        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0), (x: 3.0, y: 3.0), (x: 1.0, y: 1.0)])], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs) // Empty Set
 
         XCTAssertTrue(input == expected, "\(input) is not equal to \(expected)")
     }
 
     func testBoundary_2EqaulPoints() {
-        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 3.0, y: 3.0)]), LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 3.0, y: 3.0)])], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 3.0, y: 3.0)]), LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 3.0, y: 3.0)])], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(input == expected, "\(input) is not equal to \(expected)")
     }
 
     func testBoundary_Empty() {
-        let input = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let input = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(input == expected, "\(input) is not equal to \(expected)")
     }
 
     func testBoundary_OGC_MultiCurve_A() {
         let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.00, y: 1.0), (x: 2.0, y: 2.0), (x: 1.5, y: 3.0), (x: 2.25, y: 4.0)]),
-                                                                LineString<Coordinate2D>(elements: [(x: 2.25, y: 4.0), (x: 3.0, y: 3.0), (x: 2.5, y: 2.0), (x: 2.50, y: 1.5)])], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.5, y: 1.5))], precision: precision, coordinateReferenceSystem: crs)
+                                                                LineString<Coordinate2D>(elements: [(x: 2.25, y: 4.0), (x: 3.0, y: 3.0), (x: 2.5, y: 2.0), (x: 2.50, y: 1.5)])], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.5, y: 1.5))], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(input == expected, "\(input) is not equal to \(expected)")
     }
 
     func testBoundary_OGC_MultiCurve_B() {
         let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.00, y: 1.0), (x: 2.25, y: 4.0), (x: 2.5, y: 3.0), (x: 1.25, y: 3.5)]),
-                                                                LineString<Coordinate2D>(elements: [(x: 10.0, y: 10.0), (x: 20.0, y: 20.0), (x: 30.0, y: 30.0), (x: 10.0, y: 10.0)])], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 1.25, y: 3.5))], precision: precision, coordinateReferenceSystem: crs)
+                                                                LineString<Coordinate2D>(elements: [(x: 10.0, y: 10.0), (x: 20.0, y: 20.0), (x: 30.0, y: 30.0), (x: 10.0, y: 10.0)])], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 1.25, y: 3.5))], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(input == expected, "\(input) is not equal to \(expected)")
     }
 
     func testBoundary_OGC_MultiCurve_C() {
         let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.5, y: 3.0), (x: 1.0, y: 4.0), (x: 2.5, y: 3.5), (x: 1.5, y: 3.0)]),
-                                                                LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 0.5, y: 2.0), (x: 2.5, y: 3.5), (x: 3.0, y: 1.5), (x: 1.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+                                                                LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 0.5, y: 2.0), (x: 2.5, y: 3.5), (x: 3.0, y: 1.5), (x: 1.0, y: 1.0)])], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(input == expected, "\(input) is not equal to \(expected)")
     }
@@ -102,22 +102,22 @@ class MultiLineString_Geometry_Coordinate2D_FloatingPrecision_Cartesian_Tests: X
     func testBoundary_Odd_Intersection() {
         let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.00, y: 1.0), (x: 2.0, y: 2.0), (x: 1.5, y: 3.0), (x: 2.25, y: 4.0)]),
                                                                 LineString<Coordinate2D>(elements: [(x: 2.25, y: 4.0), (x: 3.0, y: 3.0), (x: 2.5, y: 2.0), (x: 2.50, y: 1.5)]),
-                                                                LineString<Coordinate2D>(elements: [(x: 2.25, y: 4.0), (x: 3.0, y: 5.0), (x: 2.5, y: 5.0), (x: 2.50, y: 6.0)])], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 2.25, y: 4.0)), Point<Coordinate2D>(coordinate: (x: 2.5, y: 6.0)), Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.5, y: 1.5))], precision: precision, coordinateReferenceSystem: crs)
+                                                                LineString<Coordinate2D>(elements: [(x: 2.25, y: 4.0), (x: 3.0, y: 5.0), (x: 2.5, y: 5.0), (x: 2.50, y: 6.0)])], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 2.25, y: 4.0)), Point<Coordinate2D>(coordinate: (x: 2.5, y: 6.0)), Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.5, y: 1.5))], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(input == expected, "\(input) is not equal to \(expected)")
     }
 
     func testEqual_True() {
-        let input1 = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), LineString<Coordinate2D>(elements: [(x: 3.0, y: 3.0), (x: 4.0, y: 4.0)])], precision: precision, coordinateReferenceSystem: crs)
-        let input2 = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), LineString<Coordinate2D>(elements: [(x: 3.0, y: 3.0), (x: 4.0, y: 4.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), LineString<Coordinate2D>(elements: [(x: 3.0, y: 3.0), (x: 4.0, y: 4.0)])], precision: precision, coordinateSystem: cs)
+        let input2 = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), LineString<Coordinate2D>(elements: [(x: 3.0, y: 3.0), (x: 4.0, y: 4.0)])], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input1, input2)
      }
 
      func testEqual_False() {
-        let input1            = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), LineString<Coordinate2D>(elements: [(x: 3.0, y: 3.0), (x: 4.0, y: 4.0)])], precision: precision, coordinateReferenceSystem: crs)
-        let input2: Geometry  = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input1            = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)]), LineString<Coordinate2D>(elements: [(x: 3.0, y: 3.0), (x: 4.0, y: 4.0)])], precision: precision, coordinateSystem: cs)
+        let input2: Geometry  = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
      }
@@ -128,10 +128,10 @@ class MultiLineString_Geometry_Coordinate2D_FloatingPrecision_Cartesian_Tests: X
 class MultiLineString_Geometry_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -140,10 +140,10 @@ class MultiLineString_Geometry_Coordinate2DM_FloatingPrecision_Cartesian_Tests: 
 class MultiLineString_Geometry_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiLineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiLineString<Coordinate3D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -152,10 +152,10 @@ class MultiLineString_Geometry_Coordinate3D_FloatingPrecision_Cartesian_Tests: X
 class MultiLineString_Geometry_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiLineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiLineString<Coordinate3DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -164,10 +164,10 @@ class MultiLineString_Geometry_Coordinate3DM_FloatingPrecision_Cartesian_Tests: 
 class MultiLineString_Geometry_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -176,10 +176,10 @@ class MultiLineString_Geometry_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTe
 class MultiLineString_Geometry_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -188,10 +188,10 @@ class MultiLineString_Geometry_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCT
 class MultiLineString_Geometry_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiLineString<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiLineString<Coordinate3D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -200,9 +200,9 @@ class MultiLineString_Geometry_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTe
 class MultiLineString_Geometry_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiLineString<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiLineString<Coordinate3DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }

--- a/Tests/GeoFeaturesTests/MultiLineStringTests.swift
+++ b/Tests/GeoFeaturesTests/MultiLineStringTests.swift
@@ -37,7 +37,7 @@ import GeoFeatures
 class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
@@ -50,16 +50,16 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
     func testInit_NoArg_Defaults() {
         let input    = MultiLineString<Coordinate2D>()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? FloatingPrecision, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? FloatingPrecision, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Precision() {
@@ -70,15 +70,15 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
     }
 
     func testInit_CRS() {
-        let input = MultiLineString<Coordinate2D>(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = MultiLineString<Coordinate2D>(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, expected)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, expected)
     }
 
     func testInit_Tuple() {
 
-        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
         let expected = [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])]
 
         XCTAssertTrue(
@@ -92,7 +92,7 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testDescription() {
 
-        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
         let expected = "MultiLineString<Coordinate2D>(LineString<Coordinate2D>((x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)), LineString<Coordinate2D>((x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)))"
 
         XCTAssertEqual(input.description, expected)
@@ -100,7 +100,7 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testDebugDescription() {
 
-        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
         let expected = "MultiLineString<Coordinate2D>(LineString<Coordinate2D>((x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)), LineString<Coordinate2D>((x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -110,7 +110,7 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testReserveCapacity() {
 
-        var input = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -120,7 +120,7 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testAppend() {
 
-        var input    = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)])]
 
         input.append(LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]))
@@ -132,8 +132,8 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testAppend_ContentsOf() {
 
-        let input1 = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
+        var input2 = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -142,7 +142,7 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testInsert_2ExistingElements() {
 
-        var input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
         let expected = [LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])]
 
         input.insert(LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)]), at: 0)
@@ -154,7 +154,7 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testInsert_1ExistingElements() {
 
-        var input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)])], precision: precision, coordinateSystem: cs)
         let expected = [LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)])]
 
         input.insert(LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)]), at: 0)
@@ -166,8 +166,8 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testRemove() {
 
-        var input =  MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
+        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -176,8 +176,8 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testRemoveLast() {
 
-        var input =  MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
+        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)])], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -186,8 +186,8 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testRemoveAll() {
 
-        var input =  MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected =  MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
+        let expected =  MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -196,7 +196,7 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testRemoveAll_KeepCapacity() {
 
-        var input =  MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -208,7 +208,7 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testSubscript_Get() {
 
-        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
         let expected = LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])
 
         XCTAssertTrue(input[1].equals(expected))
@@ -216,8 +216,8 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testSubscript_Set() {
 
-        var input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
+        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)])], precision: precision, coordinateSystem: cs)
 
         input[1] = LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)])
 
@@ -226,15 +226,15 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testEquals() {
 
-        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
+        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
     }
 
     func testIsEmpty() {
 
-        let input = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = true
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -242,7 +242,7 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testIsEmpty_False() {
 
-        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
         let expected = false
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -250,7 +250,7 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testCount() {
 
-        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
         let expected = 2
 
         XCTAssertEqual(input.count, expected)
@@ -260,7 +260,7 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testEnsureUniquelyReferenced() {
 
-        var input = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -273,7 +273,7 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 
     func testResizeIfNeeded() {
 
-        var input = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -288,7 +288,7 @@ class MultiLineString_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase
 class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
@@ -301,16 +301,16 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
     func testInit_NoArg_Defaults() {
         let input    = MultiLineString<Coordinate2DM>()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? FloatingPrecision, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? FloatingPrecision, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Precision() {
@@ -321,15 +321,15 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
     }
 
     func testInit_CRS() {
-        let input = MultiLineString<Coordinate2DM>(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = MultiLineString<Coordinate2DM>(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, expected)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, expected)
     }
 
     func testInit_Tuple() {
 
-        let input = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
         let expected = [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])]
 
         XCTAssertTrue(
@@ -343,7 +343,7 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testDescription() {
 
-        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
         let expected = "MultiLineString<Coordinate2DM>(LineString<Coordinate2DM>((x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)), LineString<Coordinate2DM>((x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)))"
 
         XCTAssertEqual(input.description, expected)
@@ -351,7 +351,7 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testDebugDescription() {
 
-        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
         let expected = "MultiLineString<Coordinate2DM>(LineString<Coordinate2DM>((x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)), LineString<Coordinate2DM>((x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -361,7 +361,7 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testReserveCapacity() {
 
-        var input = MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -371,7 +371,7 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testAppend() {
 
-        var input    = MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)])]
 
         input.append(LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]))
@@ -383,8 +383,8 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testAppend_ContentsOf() {
 
-        let input1 = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
+        var input2 = MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -393,7 +393,7 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testInsert_2ExistingElements() {
 
-        var input = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
         let expected = [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])]
 
         input.insert(LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)]), at: 0)
@@ -405,7 +405,7 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testInsert_1ExistingElements() {
 
-        var input = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
         let expected = [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)])]
 
         input.insert(LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)]), at: 0)
@@ -417,8 +417,8 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testRemove() {
 
-        var input =  MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
+        let expected = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -427,8 +427,8 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testRemoveLast() {
 
-        var input =  MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
+        let expected = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -437,8 +437,8 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testRemoveAll() {
 
-        var input =  MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected =  MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
+        let expected =  MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -447,7 +447,7 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testRemoveAll_KeepCapacity() {
 
-        var input =  MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -459,7 +459,7 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testSubscript_Get() {
 
-        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
         let expected = LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])
 
         XCTAssertTrue(input[1].equals(expected))
@@ -467,8 +467,8 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testSubscript_Set() {
 
-        var input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
+        let expected = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
 
         input[1] = LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)])
 
@@ -477,15 +477,15 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testEquals() {
 
-        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
+        let expected = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
     }
 
     func testIsEmpty() {
 
-        let input = MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = true
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -493,7 +493,7 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testIsEmpty_False() {
 
-        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
         let expected = false
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -501,7 +501,7 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testCount() {
 
-        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
         let expected = 2
 
         XCTAssertEqual(input.count, expected)
@@ -511,7 +511,7 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testEnsureUniquelyReferenced() {
 
-        var input = MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -524,7 +524,7 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 
     func testResizeIfNeeded() {
 
-        var input = MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -539,7 +539,7 @@ class MultiLineString_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCas
 class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
@@ -552,16 +552,16 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
     func testInit_NoArg_Defaults() {
         let input    = MultiLineString<Coordinate2D>()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? FixedPrecision, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? FixedPrecision, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Precision() {
@@ -572,15 +572,15 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
     }
 
     func testInit_CRS() {
-        let input = MultiLineString<Coordinate2D>(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = MultiLineString<Coordinate2D>(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, expected)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, expected)
     }
 
     func testInit_Tuple() {
 
-        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateSystem: cs)
         let expected = [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])]
 
         XCTAssertTrue(
@@ -594,7 +594,7 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateSystem: cs)
         let expected = "MultiLineString<Coordinate2D>(LineString<Coordinate2D>((x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)), LineString<Coordinate2D>((x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)))"
 
         XCTAssertEqual(input.description, expected)
@@ -602,7 +602,7 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateSystem: cs)
         let expected = "MultiLineString<Coordinate2D>(LineString<Coordinate2D>((x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)), LineString<Coordinate2D>((x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -612,7 +612,7 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -622,7 +622,7 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input    = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)])]
 
         input.append(LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]))
@@ -634,8 +634,8 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateSystem: cs)
+        var input2 = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -644,7 +644,7 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_2ExistingElements() {
 
-        var input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateSystem: cs)
         let expected = [LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])]
 
         input.insert(LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)]), at: 0)
@@ -656,7 +656,7 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_1ExistingElements() {
 
-        var input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)])], precision: precision, coordinateSystem: cs)
         let expected = [LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)])]
 
         input.insert(LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)]), at: 0)
@@ -668,8 +668,8 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input =  MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateSystem: cs)
+        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -678,8 +678,8 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input =  MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateSystem: cs)
+        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)])], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -688,8 +688,8 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input =  MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected =  MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateSystem: cs)
+        let expected =  MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -698,7 +698,7 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input =  MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -710,7 +710,7 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateSystem: cs)
         let expected = LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])
 
         XCTAssertTrue(input[1].equals(expected))
@@ -718,8 +718,8 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Set() {
 
-        var input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateSystem: cs)
+        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)])], precision: precision, coordinateSystem: cs)
 
         input[1] = LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)])
 
@@ -728,15 +728,15 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateSystem: cs)
+        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.0), (x: 0.0, y: 2.0), (x: 0.0, y: 3.0), (x: 2.0, y: 0.0), (x: 0.0, y: 1.0)])], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
     }
 
     func testIsEmpty() {
 
-        let input = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = true
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -744,7 +744,7 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testIsEmpty_False() {
 
-        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateSystem: cs)
         let expected = false
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -752,7 +752,7 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testCount() {
 
-        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 0.0, y: 0.0), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 0.0)]), LineString<Coordinate2D>(elements: [(x: 0.0, y: 1.001), (x: 0.0, y: 2.002), (x: 0.0, y: 3.003), (x: 2.002, y: 0.0), (x: 0.0, y: 1.001)])], precision: precision, coordinateSystem: cs)
         let expected = 2
 
         XCTAssertEqual(input.count, expected)
@@ -762,7 +762,7 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEnsureUniquelyReferenced() {
 
-        var input = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -775,7 +775,7 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -790,7 +790,7 @@ class MultiLineString_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
@@ -803,16 +803,16 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
     func testInit_NoArg_Defaults() {
         let input    = MultiLineString<Coordinate2DM>()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? FixedPrecision, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? FixedPrecision, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Precision() {
@@ -823,15 +823,15 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
     }
 
     func testInit_CRS() {
-        let input = MultiLineString<Coordinate2DM>(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = MultiLineString<Coordinate2DM>(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, expected)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, expected)
     }
 
     func testInit_Tuple() {
 
-        let input = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateSystem: cs)
         let expected = [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])]
 
         XCTAssertTrue(
@@ -845,7 +845,7 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateSystem: cs)
         let expected = "MultiLineString<Coordinate2DM>(LineString<Coordinate2DM>((x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)), LineString<Coordinate2DM>((x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)))"
 
         XCTAssertEqual(input.description, expected)
@@ -853,7 +853,7 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateSystem: cs)
         let expected = "MultiLineString<Coordinate2DM>(LineString<Coordinate2DM>((x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)), LineString<Coordinate2DM>((x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -863,7 +863,7 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -873,7 +873,7 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input    = MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)])]
 
         input.append(LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]))
@@ -885,8 +885,8 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateSystem: cs)
+        var input2 = MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -895,7 +895,7 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_2ExistingElements() {
 
-        var input = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateSystem: cs)
         let expected = [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])]
 
         input.insert(LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)]), at: 0)
@@ -907,7 +907,7 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_1ExistingElements() {
 
-        var input = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)])], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)])], precision: precision, coordinateSystem: cs)
         let expected = [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)])]
 
         input.insert(LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)]), at: 0)
@@ -919,8 +919,8 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input =  MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateSystem: cs)
+        let expected = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -929,8 +929,8 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input =  MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateSystem: cs)
+        let expected = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -939,8 +939,8 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input =  MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected =  MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateSystem: cs)
+        let expected =  MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -949,7 +949,7 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input =  MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -961,7 +961,7 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateSystem: cs)
         let expected = LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])
 
         XCTAssertTrue(input[1].equals(expected))
@@ -969,8 +969,8 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Set() {
 
-        var input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateSystem: cs)
+        let expected = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
 
         input[1] = LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)])
 
@@ -979,15 +979,15 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateSystem: cs)
+        let expected = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 0.0, m: 2.0)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.0, m: 2.0), (x: 0.0, y: 2.0, m: 2.0), (x: 0.0, y: 3.0, m: 2.0), (x: 2.0, y: 0.0, m: 2.0), (x: 0.0, y: 1.0, m: 2.0)])], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
     }
 
     func testIsEmpty() {
 
-        let input = MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = true
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -995,7 +995,7 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testIsEmpty_False() {
 
-        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateSystem: cs)
         let expected = false
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -1003,7 +1003,7 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testCount() {
 
-        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiLineString<Coordinate2DM>(elements: [LineString<Coordinate2DM>(elements: [(x: 0.0, y: 0.0, m: 2.002), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 0.0, m: 2.002)]), LineString<Coordinate2DM>(elements: [(x: 0.0, y: 1.001, m: 2.0), (x: 0.0, y: 2.002, m: 2.002), (x: 0.0, y: 3.003, m: 2.002), (x: 2.002, y: 0.0, m: 2.002), (x: 0.0, y: 1.001, m: 2.002)])], precision: precision, coordinateSystem: cs)
         let expected = 2
 
         XCTAssertEqual(input.count, expected)
@@ -1013,7 +1013,7 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEnsureUniquelyReferenced() {
 
-        var input = MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -1026,7 +1026,7 @@ class MultiLineString_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = MultiLineString<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiLineString<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity

--- a/Tests/GeoFeaturesTests/MultiPoint+GeometryTests.swift
+++ b/Tests/GeoFeaturesTests/MultiPoint+GeometryTests.swift
@@ -27,22 +27,22 @@ private let geometryDimension = Dimension.zero    // MultiPoint are always 0 dim
 class MultiPoint_Geometry_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testBoundary() {
-        let geometry = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_Empty() {
-        let geometry = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
@@ -53,22 +53,22 @@ class MultiPoint_Geometry_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTest
 class MultiPoint_Geometry_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testBoundary() {
-        let geometry = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_Empty() {
-        let geometry = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
@@ -79,22 +79,22 @@ class MultiPoint_Geometry_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTes
 class MultiPoint_Geometry_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testBoundary() {
-        let geometry = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_Empty() {
-        let geometry = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
@@ -105,22 +105,22 @@ class MultiPoint_Geometry_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTest
 class MultiPoint_Geometry_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testBoundary() {
-        let geometry = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 1.0))], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_Empty() {
-        let geometry = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
@@ -131,22 +131,22 @@ class MultiPoint_Geometry_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTes
 class MultiPoint_Geometry_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testBoundary() {
-        let geometry = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_Empty() {
-        let geometry = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
@@ -157,22 +157,22 @@ class MultiPoint_Geometry_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCas
 class MultiPoint_Geometry_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testBoundary() {
-        let geometry = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_Empty() {
-        let geometry = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
@@ -183,36 +183,36 @@ class MultiPoint_Geometry_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCa
 class MultiPoint_Geometry_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testBoundary() {
-        let geometry = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_Empty() {
-        let geometry = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testEqual_True() {
-        let input1 = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let input2 = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
+        let input2 = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input1, input2)
      }
 
      func testEqual_False() {
-        let input1            = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let input2: Geometry  = Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0), precision: precision, coordinateReferenceSystem: crs)
+        let input1            = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
+        let input2: Geometry  = Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0), precision: precision, coordinateSystem: cs)
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
      }
@@ -223,36 +223,36 @@ class MultiPoint_Geometry_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCas
 class MultiPoint_Geometry_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testBoundary() {
-        let geometry = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 1.0))], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_Empty() {
-        let geometry = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)  // Empty Set
+        let geometry = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)  // Empty Set
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testEqual_True() {
-        let input1 = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
-        let input2 = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 1.0))], precision: precision, coordinateSystem: cs)
+        let input2 = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input1, input2)
      }
 
      func testEqual_False() {
-        let input1            = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
-        let input2: Geometry  = Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0), precision: precision, coordinateReferenceSystem: crs)
+        let input1            = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 1.0))], precision: precision, coordinateSystem: cs)
+        let input2: Geometry  = Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0), precision: precision, coordinateSystem: cs)
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
      }

--- a/Tests/GeoFeaturesTests/MultiPointTests.swift
+++ b/Tests/GeoFeaturesTests/MultiPointTests.swift
@@ -37,7 +37,7 @@ import GeoFeatures
 class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
@@ -50,16 +50,16 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
     func testInit_NoArg_Defaults() {
         let input    = MultiPoint<Coordinate2D>()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? FloatingPrecision, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? FloatingPrecision, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Precision() {
@@ -70,15 +70,15 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
     }
 
     func testInit_CRS() {
-        let input = MultiPoint<Coordinate2D>(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = MultiPoint<Coordinate2D>(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, expected)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, expected)
     }
 
     func testInit_Tuple() {
 
-        let input = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))]
 
         XCTAssertTrue(
@@ -92,7 +92,7 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPoint<Coordinate2D>(Point<Coordinate2D>(x: 1.0, y: 1.0), Point<Coordinate2D>(x: 2.0, y: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -100,7 +100,7 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPoint<Coordinate2D>(Point<Coordinate2D>(x: 1.0, y: 1.0), Point<Coordinate2D>(x: 2.0, y: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -110,7 +110,7 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -120,7 +120,7 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input    = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))]
 
         input.append(Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)))
@@ -132,8 +132,8 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
+        var input2 = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -142,7 +142,7 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_2ExistingElements() {
 
-        var input = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0)), Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))]
 
         input.insert(Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0)), at: 0)
@@ -154,7 +154,7 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_1ExistingElements() {
 
-        var input = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0)), Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))]
 
         input.insert(Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0)), at: 0)
@@ -166,8 +166,8 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input =  MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -176,8 +176,8 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input =  MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -186,8 +186,8 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input =  MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected =  MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected =  MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -196,7 +196,7 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input =  MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -208,7 +208,7 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))
 
         XCTAssertTrue(input[1].equals(expected))
@@ -216,8 +216,8 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Set() {
 
-        var input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))], precision: precision, coordinateSystem: cs)
 
         input[1] = Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))
 
@@ -226,15 +226,15 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
     }
 
     func testIsEmpty() {
 
-        let input = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = true
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -242,7 +242,7 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testIsEmpty_False() {
 
-        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = false
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -250,7 +250,7 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testCount() {
 
-        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = 2
 
         XCTAssertEqual(input.count, expected)
@@ -260,7 +260,7 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEnsureUniquelyReferenced() {
 
-        var input = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -273,7 +273,7 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -288,7 +288,7 @@ class MultiPoint_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
@@ -301,16 +301,16 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
     func testInit_NoArg_Defaults() {
         let input    = MultiPoint<Coordinate2DM>()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? FloatingPrecision, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? FloatingPrecision, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Precision() {
@@ -321,15 +321,15 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
     }
 
     func testInit_CRS() {
-        let input = MultiPoint<Coordinate2DM>(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = MultiPoint<Coordinate2DM>(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, expected)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, expected)
     }
 
     func testInit_Tuple() {
 
-        let input = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))]
 
         XCTAssertTrue(
@@ -343,7 +343,7 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPoint<Coordinate2DM>(Point<Coordinate2DM>(x: 1.0, y: 1.0, m: 1.0), Point<Coordinate2DM>(x: 2.0, y: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -351,7 +351,7 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPoint<Coordinate2DM>(Point<Coordinate2DM>(x: 1.0, y: 1.0, m: 1.0), Point<Coordinate2DM>(x: 2.0, y: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -361,7 +361,7 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -371,7 +371,7 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input    = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))]
 
         input.append(Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)))
@@ -383,8 +383,8 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        var input2 = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -393,7 +393,7 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_2ExistingElements() {
 
-        var input = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0)), Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))]
 
         input.insert(Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0)), at: 0)
@@ -405,7 +405,7 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_1ExistingElements() {
 
-        var input = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0)), Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))]
 
         input.insert(Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0)), at: 0)
@@ -417,8 +417,8 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input =  MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -427,8 +427,8 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input =  MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -437,8 +437,8 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input =  MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected =  MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected =  MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -447,7 +447,7 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input =  MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -459,7 +459,7 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))
 
         XCTAssertTrue(input[1].equals(expected))
@@ -467,8 +467,8 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Set() {
 
-        var input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         input[1] = Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))
 
@@ -477,15 +477,15 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
     }
 
     func testIsEmpty() {
 
-        let input = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = true
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -493,7 +493,7 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testIsEmpty_False() {
 
-        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = false
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -501,7 +501,7 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testCount() {
 
-        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = 2
 
         XCTAssertEqual(input.count, expected)
@@ -511,7 +511,7 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEnsureUniquelyReferenced() {
 
-        var input = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -524,7 +524,7 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -539,7 +539,7 @@ class MultiPoint_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
@@ -552,16 +552,16 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
     func testInit_NoArg_Defaults() {
         let input    = MultiPoint<Coordinate3D>()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? FloatingPrecision, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? FloatingPrecision, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Precision() {
@@ -572,15 +572,15 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
     }
 
     func testInit_CRS() {
-        let input = MultiPoint<Coordinate3D>(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = MultiPoint<Coordinate3D>(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, expected)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, expected)
     }
 
     func testInit_Tuple() {
 
-        let input = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))]
 
         XCTAssertTrue(
@@ -594,7 +594,7 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPoint<Coordinate3D>(Point<Coordinate3D>(x: 1.0, y: 1.0, z: 1.0), Point<Coordinate3D>(x: 2.0, y: 2.0, z: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -602,7 +602,7 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPoint<Coordinate3D>(Point<Coordinate3D>(x: 1.0, y: 1.0, z: 1.0), Point<Coordinate3D>(x: 2.0, y: 2.0, z: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -612,7 +612,7 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -622,7 +622,7 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input    = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))]
 
         input.append(Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)))
@@ -634,8 +634,8 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
+        var input2 = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -644,7 +644,7 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_2ExistingElements() {
 
-        var input = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0)), Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))]
 
         input.insert(Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0)), at: 0)
@@ -656,7 +656,7 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_1ExistingElements() {
 
-        var input = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0)), Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))]
 
         input.insert(Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0)), at: 0)
@@ -668,8 +668,8 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input =  MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -678,8 +678,8 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input =  MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -688,8 +688,8 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input =  MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected =  MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected =  MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -698,7 +698,7 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input =  MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -710,7 +710,7 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))
 
         XCTAssertTrue(input[1].equals(expected))
@@ -718,8 +718,8 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Set() {
 
-        var input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateSystem: cs)
 
         input[1] = Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))
 
@@ -728,15 +728,15 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
     }
 
     func testIsEmpty() {
 
-        let input = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = true
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -744,7 +744,7 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testIsEmpty_False() {
 
-        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = false
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -752,7 +752,7 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testCount() {
 
-        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = 2
 
         XCTAssertEqual(input.count, expected)
@@ -762,7 +762,7 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEnsureUniquelyReferenced() {
 
-        var input = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -775,7 +775,7 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -790,7 +790,7 @@ class MultiPoint_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
@@ -803,16 +803,16 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
     func testInit_NoArg_Defaults() {
         let input    = MultiPoint<Coordinate3DM>()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? FloatingPrecision, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? FloatingPrecision, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Precision() {
@@ -823,15 +823,15 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
     }
 
     func testInit_CRS() {
-        let input = MultiPoint<Coordinate3DM>(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = MultiPoint<Coordinate3DM>(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, expected)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, expected)
     }
 
     func testInit_Tuple() {
 
-        let input = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         XCTAssertTrue(
@@ -845,7 +845,7 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPoint<Coordinate3DM>(Point<Coordinate3DM>(x: 1.0, y: 1.0, z: 1.0, m: 1.0), Point<Coordinate3DM>(x: 2.0, y: 2.0, z: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -853,7 +853,7 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPoint<Coordinate3DM>(Point<Coordinate3DM>(x: 1.0, y: 1.0, z: 1.0, m: 1.0), Point<Coordinate3DM>(x: 2.0, y: 2.0, z: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -863,7 +863,7 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -873,7 +873,7 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input    = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))]
 
         input.append(Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)))
@@ -885,8 +885,8 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        var input2 = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -895,7 +895,7 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_2ExistingElements() {
 
-        var input = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         input.insert(Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), at: 0)
@@ -907,7 +907,7 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_1ExistingElements() {
 
-        var input = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))]
 
         input.insert(Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), at: 0)
@@ -919,8 +919,8 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input =  MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -929,8 +929,8 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input =  MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -939,8 +939,8 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input =  MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected =  MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected =  MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -949,7 +949,7 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input =  MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -961,7 +961,7 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))
 
         XCTAssertTrue(input[1].equals(expected))
@@ -969,8 +969,8 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Set() {
 
-        var input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         input[1] = Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))
 
@@ -979,15 +979,15 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
     }
 
     func testIsEmpty() {
 
-        let input = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = true
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -995,7 +995,7 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testIsEmpty_False() {
 
-        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = false
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -1003,7 +1003,7 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testCount() {
 
-        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
         let expected = 2
 
         XCTAssertEqual(input.count, expected)
@@ -1013,7 +1013,7 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEnsureUniquelyReferenced() {
 
-        var input = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -1026,7 +1026,7 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -1041,7 +1041,7 @@ class MultiPoint_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
@@ -1054,16 +1054,16 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
     func testInit_NoArg_Defaults() {
         let input    = MultiPoint<Coordinate2D>()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? FixedPrecision, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? FixedPrecision, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Precision() {
@@ -1074,15 +1074,15 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
     }
 
     func testInit_CRS() {
-        let input = MultiPoint<Coordinate2D>(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = MultiPoint<Coordinate2D>(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, expected)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, expected)
     }
 
     func testInit_Tuple() {
 
-        let input = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))]
 
         XCTAssertTrue(
@@ -1096,7 +1096,7 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPoint<Coordinate2D>(Point<Coordinate2D>(x: 1.0, y: 1.0), Point<Coordinate2D>(x: 2.0, y: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -1104,7 +1104,7 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPoint<Coordinate2D>(Point<Coordinate2D>(x: 1.0, y: 1.0), Point<Coordinate2D>(x: 2.0, y: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -1114,7 +1114,7 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -1124,7 +1124,7 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input    = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))]
 
         input.append(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)))
@@ -1136,8 +1136,8 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
+        var input2 = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -1146,7 +1146,7 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_2ExistingElements() {
 
-        var input = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0)), Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))]
 
         input.insert(Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002)), at: 0)
@@ -1158,7 +1158,7 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_1ExistingElements() {
 
-        var input = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0)), Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))]
 
         input.insert(Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002)), at: 0)
@@ -1170,8 +1170,8 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input =  MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -1180,8 +1180,8 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input =  MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -1190,8 +1190,8 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input =  MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected =  MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected =  MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -1200,7 +1200,7 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input =  MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -1212,7 +1212,7 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))
 
         XCTAssertTrue(input[1].equals(expected))
@@ -1220,8 +1220,8 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Set() {
 
-        var input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0))], precision: precision, coordinateSystem: cs)
 
         input[1] = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001))
 
@@ -1230,15 +1230,15 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0)), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
     }
 
     func testIsEmpty() {
 
-        let input = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = true
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -1246,7 +1246,7 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testIsEmpty_False() {
 
-        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = false
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -1254,7 +1254,7 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testCount() {
 
-        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2D>(elements: [Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001)), Point<Coordinate2D>(coordinate: (x: 2.002, y: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = 2
 
         XCTAssertEqual(input.count, expected)
@@ -1264,7 +1264,7 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEnsureUniquelyReferenced() {
 
-        var input = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -1277,7 +1277,7 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -1292,7 +1292,7 @@ class MultiPoint_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
@@ -1305,16 +1305,16 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
     func testInit_NoArg_Defaults() {
         let input    = MultiPoint<Coordinate2DM>()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? FixedPrecision, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? FixedPrecision, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Precision() {
@@ -1325,15 +1325,15 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
     }
 
     func testInit_CRS() {
-        let input = MultiPoint<Coordinate2DM>(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = MultiPoint<Coordinate2DM>(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, expected)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, expected)
     }
 
     func testInit_Tuple() {
 
-        let input = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))]
 
         XCTAssertTrue(
@@ -1347,7 +1347,7 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPoint<Coordinate2DM>(Point<Coordinate2DM>(x: 1.0, y: 1.0, m: 1.0), Point<Coordinate2DM>(x: 2.0, y: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -1355,7 +1355,7 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPoint<Coordinate2DM>(Point<Coordinate2DM>(x: 1.0, y: 1.0, m: 1.0), Point<Coordinate2DM>(x: 2.0, y: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -1365,7 +1365,7 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -1375,7 +1375,7 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input    = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))]
 
         input.append(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)))
@@ -1387,8 +1387,8 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        var input2 = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -1397,7 +1397,7 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_2ExistingElements() {
 
-        var input = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0)), Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))]
 
         input.insert(Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002)), at: 0)
@@ -1409,7 +1409,7 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_1ExistingElements() {
 
-        var input = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0)), Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))]
 
         input.insert(Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002)), at: 0)
@@ -1421,8 +1421,8 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input =  MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -1431,8 +1431,8 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input =  MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -1441,8 +1441,8 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input =  MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected =  MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected =  MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -1451,7 +1451,7 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input =  MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -1463,7 +1463,7 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))
 
         XCTAssertTrue(input[1].equals(expected))
@@ -1471,8 +1471,8 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Set() {
 
-        var input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         input[1] = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001))
 
@@ -1481,15 +1481,15 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0)), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
     }
 
     func testIsEmpty() {
 
-        let input = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = true
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -1497,7 +1497,7 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testIsEmpty_False() {
 
-        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = false
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -1505,7 +1505,7 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testCount() {
 
-        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate2DM>(elements: [Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001)), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = 2
 
         XCTAssertEqual(input.count, expected)
@@ -1515,7 +1515,7 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEnsureUniquelyReferenced() {
 
-        var input = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -1528,7 +1528,7 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -1543,7 +1543,7 @@ class MultiPoint_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
@@ -1556,16 +1556,16 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
     func testInit_NoArg_Defaults() {
         let input    = MultiPoint<Coordinate3D>()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? FixedPrecision, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? FixedPrecision, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Precision() {
@@ -1576,15 +1576,15 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
     }
 
     func testInit_CRS() {
-        let input = MultiPoint<Coordinate3D>(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = MultiPoint<Coordinate3D>(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, expected)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, expected)
     }
 
     func testInit_Tuple() {
 
-        let input = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))]
 
         XCTAssertTrue(
@@ -1598,7 +1598,7 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPoint<Coordinate3D>(Point<Coordinate3D>(x: 1.0, y: 1.0, z: 1.0), Point<Coordinate3D>(x: 2.0, y: 2.0, z: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -1606,7 +1606,7 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPoint<Coordinate3D>(Point<Coordinate3D>(x: 1.0, y: 1.0, z: 1.0), Point<Coordinate3D>(x: 2.0, y: 2.0, z: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -1616,7 +1616,7 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -1626,7 +1626,7 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input    = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))]
 
         input.append(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)))
@@ -1638,8 +1638,8 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
+        var input2 = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -1648,7 +1648,7 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_2ExistingElements() {
 
-        var input = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0)), Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))]
 
         input.insert(Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002)), at: 0)
@@ -1660,7 +1660,7 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_1ExistingElements() {
 
-        var input = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0)), Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))]
 
         input.insert(Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002)), at: 0)
@@ -1672,8 +1672,8 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input =  MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -1682,8 +1682,8 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input =  MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -1692,8 +1692,8 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input =  MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected =  MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected =  MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -1702,7 +1702,7 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input =  MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -1714,7 +1714,7 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))
 
         XCTAssertTrue(input[1].equals(expected))
@@ -1722,8 +1722,8 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Set() {
 
-        var input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0))], precision: precision, coordinateSystem: cs)
 
         input[1] = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001))
 
@@ -1732,15 +1732,15 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0)), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
     }
 
     func testIsEmpty() {
 
-        let input = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = true
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -1748,7 +1748,7 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testIsEmpty_False() {
 
-        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = false
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -1756,7 +1756,7 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testCount() {
 
-        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3D>(elements: [Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001)), Point<Coordinate3D>(coordinate: (x: 2.002, y: 2.002, z: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = 2
 
         XCTAssertEqual(input.count, expected)
@@ -1766,7 +1766,7 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEnsureUniquelyReferenced() {
 
-        var input = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -1779,7 +1779,7 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity
@@ -1794,7 +1794,7 @@ class MultiPoint_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
@@ -1807,16 +1807,16 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
     func testInit_NoArg_Defaults() {
         let input    = MultiPoint<Coordinate3DM>()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? FixedPrecision, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? FixedPrecision, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Precision() {
@@ -1827,15 +1827,15 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
     }
 
     func testInit_CRS() {
-        let input = MultiPoint<Coordinate3DM>(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = MultiPoint<Coordinate3DM>(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, expected)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, expected)
     }
 
     func testInit_Tuple() {
 
-        let input = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         XCTAssertTrue(
@@ -1849,7 +1849,7 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPoint<Coordinate3DM>(Point<Coordinate3DM>(x: 1.0, y: 1.0, z: 1.0, m: 1.0), Point<Coordinate3DM>(x: 2.0, y: 2.0, z: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.description, expected)
@@ -1857,7 +1857,7 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPoint<Coordinate3DM>(Point<Coordinate3DM>(x: 1.0, y: 1.0, z: 1.0, m: 1.0), Point<Coordinate3DM>(x: 2.0, y: 2.0, z: 2.0, m: 2.0))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -1867,7 +1867,7 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -1877,7 +1877,7 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input    = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))]
 
         input.append(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)))
@@ -1889,8 +1889,8 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        var input2 = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -1899,7 +1899,7 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_2ExistingElements() {
 
-        var input = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))]
 
         input.insert(Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002)), at: 0)
@@ -1911,7 +1911,7 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_1ExistingElements() {
 
-        var input = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001))], precision: precision, coordinateSystem: cs)
         let expected = [Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0)), Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))]
 
         input.insert(Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002)), at: 0)
@@ -1923,8 +1923,8 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input =  MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -1933,8 +1933,8 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input =  MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -1943,8 +1943,8 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input =  MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected =  MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected =  MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -1953,7 +1953,7 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input =  MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -1965,7 +1965,7 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))
 
         XCTAssertTrue(input[1].equals(expected))
@@ -1973,8 +1973,8 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Set() {
 
-        var input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0))], precision: precision, coordinateSystem: cs)
 
         input[1] = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001))
 
@@ -1983,15 +1983,15 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0)), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0))], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
     }
 
     func testIsEmpty() {
 
-        let input = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = true
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -1999,7 +1999,7 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testIsEmpty_False() {
 
-        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = false
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -2007,7 +2007,7 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testCount() {
 
-        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPoint<Coordinate3DM>(elements: [Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001)), Point<Coordinate3DM>(coordinate: (x: 2.002, y: 2.002, z: 2.002, m: 2.002))], precision: precision, coordinateSystem: cs)
         let expected = 2
 
         XCTAssertEqual(input.count, expected)
@@ -2017,7 +2017,7 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testEnsureUniquelyReferenced() {
 
-        var input = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -2030,7 +2030,7 @@ class MultiPoint_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity

--- a/Tests/GeoFeaturesTests/MultiPolygon+GeometryTests.swift
+++ b/Tests/GeoFeaturesTests/MultiPolygon+GeometryTests.swift
@@ -32,58 +32,58 @@ private let geometryDimension = Dimension.two    // MultiPolygon are always 2 di
 class MultiPolygon_Geometry_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiPolygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiPolygon<Coordinate2D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testBoundary_Single_Polygon_NoInnerRings() {
 
-        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)])], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(input == expected, "\(input) is not equal to \(expected)")
     }
 
     func testBoundary_Single_Polygon_InnnerRings() {
-        let input = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]]))], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)]), LineString<Coordinate2D>(elements: [(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]]))], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)]), LineString<Coordinate2D>(elements: [(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)])], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(input == expected, "\(input) is not equal to \(expected)")
     }
 
     func testBoundary_Multiple_Polygons() {
-        let input = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)]), LineString<Coordinate2D>(elements: [(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]), LineString<Coordinate2D>(elements: [(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)]), LineString<Coordinate2D>(elements: [(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]), LineString<Coordinate2D>(elements: [(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)])], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(input == expected, "\(input) is not equal to \(expected)")
     }
 
     func testBoundary_Empty() {
-        let geometry = MultiPolygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let geometry = MultiPolygon<Coordinate2D>(precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testEqual_True() {
-        let input1 = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
-        let input2 = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
+        let input2 = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input1, input2)
      }
 
     func testEqual_SameTypes_False() {
-        let input1            = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
-        let input2: Geometry  = MultiPolygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input1            = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
+        let input2: Geometry  = MultiPolygon<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
     }
 
      func testEqual_DifferentTypes_False() {
-        let input1            = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
-        let input2: Geometry  = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateReferenceSystem: crs)
+        let input1            = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
+        let input2: Geometry  = LineString<Coordinate2D>(elements: [(x: 1.0, y: 1.0), (x: 2.0, y: 2.0)], precision: precision, coordinateSystem: cs)
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
      }
@@ -94,10 +94,10 @@ class MultiPolygon_Geometry_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTe
 class MultiPolygon_Geometry_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiPolygon<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiPolygon<Coordinate2DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -106,10 +106,10 @@ class MultiPolygon_Geometry_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCT
 class MultiPolygon_Geometry_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiPolygon<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiPolygon<Coordinate3D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -118,10 +118,10 @@ class MultiPolygon_Geometry_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTe
 class MultiPolygon_Geometry_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiPolygon<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiPolygon<Coordinate3DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -130,10 +130,10 @@ class MultiPolygon_Geometry_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCT
 class MultiPolygon_Geometry_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiPolygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiPolygon<Coordinate2D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -142,10 +142,10 @@ class MultiPolygon_Geometry_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestC
 class MultiPolygon_Geometry_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiPolygon<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiPolygon<Coordinate2DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -154,10 +154,10 @@ class MultiPolygon_Geometry_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTest
 class MultiPolygon_Geometry_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiPolygon<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiPolygon<Coordinate3D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -166,9 +166,9 @@ class MultiPolygon_Geometry_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestC
 class MultiPolygon_Geometry_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(MultiPolygon<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(MultiPolygon<Coordinate3DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }

--- a/Tests/GeoFeaturesTests/MultiPolygon+SurfaceTests.swift
+++ b/Tests/GeoFeaturesTests/MultiPolygon+SurfaceTests.swift
@@ -30,10 +30,10 @@ import GeoFeatures
 class MultiPolygon_Surface_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100000)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testArea_Empty() {
-        let input    = MultiPolygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPolygon<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = 0.0
 
         XCTAssertEqual(input.area(), expected)
@@ -41,7 +41,7 @@ class MultiPolygon_Surface_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCa
 
     func testArea_2_Same_Polygons() {
 
-        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 0, y: 0), (x: 0, y: 6), (x: 6, y: 6), (x: 6, y: 0), (x: 0, y: 0)], [[(x: 1, y: 1), (x: 4, y: 1), (x: 4, y: 2), (x: 1, y: 2), (x: 1, y: 1)]])), Polygon<Coordinate2D>(rings: ([(x: 0, y: 0), (x: 0, y: 6), (x: 6, y: 6), (x: 6, y: 0), (x: 0, y: 0)], [[(x: 1, y: 1), (x: 4, y: 1), (x: 4, y: 2), (x: 1, y: 2), (x: 1, y: 1)]]))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 0, y: 0), (x: 0, y: 6), (x: 6, y: 6), (x: 6, y: 0), (x: 0, y: 0)], [[(x: 1, y: 1), (x: 4, y: 1), (x: 4, y: 2), (x: 1, y: 2), (x: 1, y: 1)]])), Polygon<Coordinate2D>(rings: ([(x: 0, y: 0), (x: 0, y: 6), (x: 6, y: 6), (x: 6, y: 0), (x: 0, y: 0)], [[(x: 1, y: 1), (x: 4, y: 1), (x: 4, y: 2), (x: 1, y: 2), (x: 1, y: 1)]]))], precision: precision, coordinateSystem: cs)
         let expected = 66.0
 
         XCTAssertEqual(input.area(), expected)
@@ -49,7 +49,7 @@ class MultiPolygon_Surface_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCa
 
     func testArea_2_Different_Polygons() {
 
-        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 0, y: 0), (x: 0, y: 6), (x: 6, y: 6), (x: 6, y: 0), (x: 0, y: 0)], [[(x: 1, y: 1), (x: 4, y: 1), (x: 4, y: 2), (x: 1, y: 2), (x: 1, y: 1)]])), Polygon<Coordinate2D>(rings: ([(x: 0, y: 0), (x: 0, y: 6), (x: 6, y: 6), (x: 6, y: 0), (x: 0, y: 0)], []))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 0, y: 0), (x: 0, y: 6), (x: 6, y: 6), (x: 6, y: 0), (x: 0, y: 0)], [[(x: 1, y: 1), (x: 4, y: 1), (x: 4, y: 2), (x: 1, y: 2), (x: 1, y: 1)]])), Polygon<Coordinate2D>(rings: ([(x: 0, y: 0), (x: 0, y: 6), (x: 6, y: 6), (x: 6, y: 0), (x: 0, y: 0)], []))], precision: precision, coordinateSystem: cs)
         let expected = 69.0
 
         XCTAssertEqual(input.area(), expected)

--- a/Tests/GeoFeaturesTests/MultiPolygonTests.swift
+++ b/Tests/GeoFeaturesTests/MultiPolygonTests.swift
@@ -37,7 +37,7 @@ import GeoFeatures
 class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     // MARK: Construction
 
@@ -50,16 +50,16 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
     func testInit_NoArg_Defaults() {
         let input    = MultiPolygon<Coordinate2D>()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? FloatingPrecision, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = MultiPolygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPolygon<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? FloatingPrecision, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Precision() {
@@ -70,15 +70,15 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
     }
 
     func testInit_CRS() {
-        let input = MultiPolygon<Coordinate2D>(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = MultiPolygon<Coordinate2D>(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, expected)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, expected)
     }
 
     func testInit_Tuple() {
 
-        let input = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
         let expected = [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))]
 
         XCTAssertTrue(
@@ -92,7 +92,7 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPolygon<Coordinate2D>(Polygon<Coordinate2D>([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []), Polygon<Coordinate2D>([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))"
 
         XCTAssertEqual(input.description, expected)
@@ -100,7 +100,7 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
         let expected = "MultiPolygon<Coordinate2D>(Polygon<Coordinate2D>([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []), Polygon<Coordinate2D>([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -110,7 +110,7 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testReserveCapacity() {
 
-        var input = MultiPolygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPolygon<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         input.reserveCapacity(expected)
@@ -120,7 +120,7 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend() {
 
-        var input    = MultiPolygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPolygon<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))]
 
         input.append(Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])))
@@ -132,8 +132,8 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testAppend_ContentsOf() {
 
-        let input1 = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
-        var input2 = MultiPolygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input1 = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
+        var input2 = MultiPolygon<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input2.append(contentsOf: input1)
 
@@ -142,7 +142,7 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_2ExistingElements() {
 
-        var input = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
         let expected = [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))]
 
         input.insert(Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), at: 0)
@@ -154,7 +154,7 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInsert_1ExistingElements() {
 
-        var input = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
         let expected = [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))]
 
         input.insert(Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), at: 0)
@@ -166,8 +166,8 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemove() {
 
-        var input =  MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
 
         let _ = input.remove(at: 0)
 
@@ -176,8 +176,8 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveLast() {
 
-        var input =  MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
 
         let _ = input.removeLast()
 
@@ -186,8 +186,8 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll() {
 
-        var input =  MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
-        let expected =  MultiPolygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
+        let expected =  MultiPolygon<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         input.removeAll()
 
@@ -196,7 +196,7 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testRemoveAll_KeepCapacity() {
 
-        var input =  MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
+        var input =  MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
         let expected = input.capacity
 
         input.removeAll(keepingCapacity: true)
@@ -208,7 +208,7 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Get() {
 
-        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
         let expected = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))
 
         XCTAssertTrue(input[1].equals(expected))
@@ -216,8 +216,8 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testSubscript_Set() {
 
-        var input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
+        var input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
 
         input[1] = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))
 
@@ -226,15 +226,15 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEquals() {
 
-        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
-        let expected = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
+        let expected = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
     }
 
     func testIsEmpty() {
 
-        let input = MultiPolygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input = MultiPolygon<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = true
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -242,7 +242,7 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testIsEmpty_False() {
 
-        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
         let expected = false
 
         XCTAssertEqual(input.isEmpty(), expected)
@@ -250,7 +250,7 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testCount() {
 
-        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateReferenceSystem: crs)
+        let input    = MultiPolygon<Coordinate2D>(elements: [Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [])), Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []))], precision: precision, coordinateSystem: cs)
         let expected = 2
 
         XCTAssertEqual(input.count, expected)
@@ -260,7 +260,7 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testEnsureUniquelyReferenced() {
 
-        var input = MultiPolygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPolygon<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         let copy = input    // This should force the reserveCapacity to clone
@@ -273,7 +273,7 @@ class MultiPolygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testResizeIfNeeded() {
 
-        var input = MultiPolygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        var input = MultiPolygon<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = input.capacity * 2
 
         // Force it beyond its initial capacity

--- a/Tests/GeoFeaturesTests/Point+GeometryTests.swift
+++ b/Tests/GeoFeaturesTests/Point+GeometryTests.swift
@@ -27,34 +27,34 @@ private let geometryDimension = Dimension.zero   // Point always have a 0 dimens
 class Point_Geometry_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension() {
-        XCTAssertEqual(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testIsEmpty() {
-        XCTAssertEqual(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testEquals_IntOne_True() {
-        XCTAssertEqual(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs), Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs))
+        XCTAssertEqual(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs), Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs))
     }
 
     func testEquals_IntOne_False() {
-        XCTAssertNotEqual(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0), precision: precision, coordinateReferenceSystem: crs))
+        XCTAssertNotEqual(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0), precision: precision, coordinateSystem: cs))
     }
 
     func testEquals_Point_NonPoint_False() {
-        let input1           = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input1           = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs)
         let input2: Geometry = LineString<Coordinate2D>()
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
     }
 
     func testBoundary() {
-        let geometry = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let geometry = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
@@ -65,34 +65,34 @@ class Point_Geometry_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase 
 class Point_Geometry_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension() {
-        XCTAssertEqual(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testIsEmpty() {
-        XCTAssertEqual(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testEquals_IntOne_True() {
-        XCTAssertEqual(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs), Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs))
+        XCTAssertEqual(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs), Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs))
     }
 
     func testEquals_IntOne_False() {
-        XCTAssertNotEqual(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002), precision: precision, coordinateReferenceSystem: crs))
+        XCTAssertNotEqual(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs), Point<Coordinate2DM>(coordinate: (x: 2.002, y: 2.002, m: 2.002), precision: precision, coordinateSystem: cs))
     }
 
     func testEquals_Point_NonPoint_False() {
-        let input1           = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input1           = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs)
         let input2: Geometry = LineString<Coordinate2DM>()
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
     }
 
     func testBoundary() {
-        let geometry = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let geometry = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
@@ -103,34 +103,34 @@ class Point_Geometry_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase
 class Point_Geometry_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension() {
-        XCTAssertEqual(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testIsEmpty() {
-        XCTAssertEqual(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testEquals_IntOne_True() {
-        XCTAssertEqual(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs), Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs))
+        XCTAssertEqual(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs), Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs))
     }
 
     func testEquals_IntOne_False() {
-        XCTAssertNotEqual(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0), precision: precision, coordinateReferenceSystem: crs))
+        XCTAssertNotEqual(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0), precision: precision, coordinateSystem: cs))
     }
 
     func testEquals_Point_NonPoint_False() {
-        let input1           = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input1           = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs)
         let input2: Geometry = LineString<Coordinate3D>()
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
     }
 
     func testBoundary() {
-        let geometry = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        let geometry = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
@@ -141,34 +141,34 @@ class Point_Geometry_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase 
 class Point_Geometry_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension() {
-        XCTAssertEqual(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testIsEmpty() {
-        XCTAssertEqual(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testEquals_IntOne_True() {
-        XCTAssertEqual(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs), Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs))
+        XCTAssertEqual(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs), Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs))
     }
 
     func testEquals_IntOne_False() {
-        XCTAssertNotEqual(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0), precision: precision, coordinateReferenceSystem: crs))
+        XCTAssertNotEqual(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0), precision: precision, coordinateSystem: cs))
     }
 
     func testEquals_Point_NonPoint_False() {
-        let input1           = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input1           = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs)
         let input2: Geometry = LineString<Coordinate3DM>()
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
     }
 
     func testBoundary() {
-        let geometry = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        let geometry = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
@@ -179,34 +179,34 @@ class Point_Geometry_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase
 class Point_Geometry_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension() {
-        XCTAssertEqual(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testIsEmpty() {
-        XCTAssertEqual(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testEquals_IntOne_True() {
-        XCTAssertEqual(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs), Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0), precision: precision, coordinateReferenceSystem: crs))
+        XCTAssertEqual(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs), Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0), precision: precision, coordinateSystem: cs))
     }
 
     func testEquals_IntOne_False() {
-        XCTAssertNotEqual(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0), precision: precision, coordinateReferenceSystem: crs))
+        XCTAssertNotEqual(Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs), Point<Coordinate2D>(coordinate: (x: 2.0, y: 2.0), precision: precision, coordinateSystem: cs))
     }
 
     func testEquals_Point_NonPoint_False() {
-        let input1           = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input1           = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs)
         let input2: Geometry = LineString<Coordinate2D>()
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
     }
 
     func testBoundary() {
-        let geometry = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let geometry = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
@@ -217,34 +217,34 @@ class Point_Geometry_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 class Point_Geometry_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension() {
-        XCTAssertEqual(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testIsEmpty() {
-        XCTAssertEqual(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testEquals_IntOne_True() {
-        XCTAssertEqual(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs), Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0), precision: precision, coordinateReferenceSystem: crs))
+        XCTAssertEqual(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs), Point<Coordinate2DM>(coordinate: (x: 1.0, y: 1.0, m: 1.0), precision: precision, coordinateSystem: cs))
     }
 
     func testEquals_IntOne_False() {
-        XCTAssertNotEqual(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0), precision: precision, coordinateReferenceSystem: crs))
+        XCTAssertNotEqual(Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs), Point<Coordinate2DM>(coordinate: (x: 2.0, y: 2.0, m: 2.0), precision: precision, coordinateSystem: cs))
     }
 
     func testEquals_Point_NonPoint_False() {
-        let input1           = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input1           = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs)
         let input2: Geometry = LineString<Coordinate2DM>()
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
     }
 
     func testBoundary() {
-        let geometry = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs)
+        let geometry = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate2DM>(precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
@@ -255,34 +255,34 @@ class Point_Geometry_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 class Point_Geometry_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension() {
-        XCTAssertEqual(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testIsEmpty() {
-        XCTAssertEqual(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testEquals_IntOne_True() {
-        XCTAssertEqual(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs), Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0), precision: precision, coordinateReferenceSystem: crs))
+        XCTAssertEqual(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs), Point<Coordinate3D>(coordinate: (x: 1.0, y: 1.0, z: 1.0), precision: precision, coordinateSystem: cs))
     }
 
     func testEquals_IntOne_False() {
-        XCTAssertNotEqual(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0), precision: precision, coordinateReferenceSystem: crs))
+        XCTAssertNotEqual(Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs), Point<Coordinate3D>(coordinate: (x: 2.0, y: 2.0, z: 2.0), precision: precision, coordinateSystem: cs))
     }
 
     func testEquals_Point_NonPoint_False() {
-        let input1           = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input1           = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs)
         let input2: Geometry = LineString<Coordinate3D>()
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
     }
 
     func testBoundary() {
-        let geometry = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs)
+        let geometry = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate3D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
@@ -293,34 +293,34 @@ class Point_Geometry_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 class Point_Geometry_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension() {
-        XCTAssertEqual(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testIsEmpty() {
-        XCTAssertEqual(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs).isEmpty(), false)
+        XCTAssertEqual(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs).isEmpty(), false)
     }
 
     func testEquals_IntOne_True() {
-        XCTAssertEqual(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs), Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0), precision: precision, coordinateReferenceSystem: crs))
+        XCTAssertEqual(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs), Point<Coordinate3DM>(coordinate: (x: 1.0, y: 1.0, z: 1.0, m: 1.0), precision: precision, coordinateSystem: cs))
     }
 
     func testEquals_IntOne_False() {
-        XCTAssertNotEqual(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0), precision: precision, coordinateReferenceSystem: crs))
+        XCTAssertNotEqual(Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs), Point<Coordinate3DM>(coordinate: (x: 2.0, y: 2.0, z: 2.0, m: 2.0), precision: precision, coordinateSystem: cs))
     }
 
     func testEquals_Point_NonPoint_False() {
-        let input1           = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input1           = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs)
         let input2: Geometry = LineString<Coordinate3DM>()
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
     }
 
     func testBoundary() {
-        let geometry = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiPoint<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs)
+        let geometry = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiPoint<Coordinate3DM>(precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }

--- a/Tests/GeoFeaturesTests/PointTests.swift
+++ b/Tests/GeoFeaturesTests/PointTests.swift
@@ -25,10 +25,10 @@ import GeoFeatures
 class Point_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testInit() {
-        let input = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.x, 1.001)
         XCTAssertEqual(input.y, 1.001)
@@ -37,13 +37,13 @@ class Point_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
     // MARK: CustomStringConvertible & CustomDebugStringConvertible
 
     func testDescription() {
-        let input = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.description, "Point<Coordinate2D>(x: 1.001, y: 1.001)")
     }
 
     func testDebugDescription() {
-        let input = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.debugDescription, "Point<Coordinate2D>(x: 1.001, y: 1.001)")
     }
@@ -54,10 +54,10 @@ class Point_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class Point_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testInit() {
-        let input = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.x, 1.001)
         XCTAssertEqual(input.y, 1.001)
@@ -67,13 +67,13 @@ class Point_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
     // MARK: CustomStringConvertible & CustomDebugStringConvertible
 
     func testDescription() {
-        let input = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.description, "Point<Coordinate2DM>(x: 1.001, y: 1.001, m: 1.001)")
     }
 
     func testDebugDescription() {
-        let input = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.debugDescription, "Point<Coordinate2DM>(x: 1.001, y: 1.001, m: 1.001)")
     }
@@ -84,10 +84,10 @@ class Point_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class Point_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testInit() {
-        let input = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.x, 1.001)
         XCTAssertEqual(input.y, 1.001)
@@ -97,13 +97,13 @@ class Point_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
     // MARK: CustomStringConvertible & CustomDebugStringConvertible
 
     func testDescription() {
-        let input = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.description, "Point<Coordinate3D>(x: 1.001, y: 1.001, z: 1.001)")
     }
 
     func testDebugDescription() {
-        let input = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.debugDescription, "Point<Coordinate3D>(x: 1.001, y: 1.001, z: 1.001)")
     }
@@ -114,10 +114,10 @@ class Point_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class Point_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testInit() {
-        let input = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.x, 1.001)
         XCTAssertEqual(input.y, 1.001)
@@ -128,13 +128,13 @@ class Point_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
     // MARK: CustomStringConvertible & CustomDebugStringConvertible
 
     func testDescription() {
-        let input = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.description, "Point<Coordinate3DM>(x: 1.001, y: 1.001, z: 1.001, m: 1.001)")
     }
 
     func testDebugDescription() {
-        let input = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.debugDescription, "Point<Coordinate3DM>(x: 1.001, y: 1.001, z: 1.001, m: 1.001)")
     }
@@ -145,10 +145,10 @@ class Point_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class Point_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testInit() {
-        let input = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input = Point<Coordinate2D>(coordinate: (x: 1.001, y: 1.001), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.x, 1.0)
         XCTAssertEqual(input.y, 1.0)
@@ -160,10 +160,10 @@ class Point_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 class Point_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testInit() {
-        let input = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input = Point<Coordinate2DM>(coordinate: (x: 1.001, y: 1.001, m: 1.001), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.x, 1.0)
         XCTAssertEqual(input.y, 1.0)
@@ -176,10 +176,10 @@ class Point_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 class Point_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testInit() {
-        let input = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input = Point<Coordinate3D>(coordinate: (x: 1.001, y: 1.001, z: 1.001), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.x, 1.0)
         XCTAssertEqual(input.y, 1.0)
@@ -192,10 +192,10 @@ class Point_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 class Point_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testInit() {
-        let input = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateReferenceSystem: crs)
+        let input = Point<Coordinate3DM>(coordinate: (x: 1.001, y: 1.001, z: 1.001, m: 1.001), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.x, 1.0)
         XCTAssertEqual(input.y, 1.0)

--- a/Tests/GeoFeaturesTests/Polygon+GeometryTests.swift
+++ b/Tests/GeoFeaturesTests/Polygon+GeometryTests.swift
@@ -32,43 +32,43 @@ private let geometryDimension = Dimension.two    // Polygon are always 2 dimensi
 class Polygon_Geometry_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(Polygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(Polygon<Coordinate2D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 
     func testBoundary_OuterRing() {
-        let geometry = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []), precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let geometry = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], []), precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)])], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_OuterRing_1InnerRing() {
-        let geometry = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)]), LineString<Coordinate2D>(elements: [(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)])], precision: precision, coordinateReferenceSystem: crs)
+        let geometry = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiLineString<Coordinate2D>(elements: [LineString<Coordinate2D>(elements: [(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)]), LineString<Coordinate2D>(elements: [(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)])], precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testBoundary_Empty() {
-        let geometry = Polygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).boundary()
-        let expected = MultiLineString<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let geometry = Polygon<Coordinate2D>(precision: precision, coordinateSystem: cs).boundary()
+        let expected = MultiLineString<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(geometry == expected, "\(geometry) is not equal to \(expected)")
     }
 
     func testEqual_True() {
-        let input1 = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs)
-        let input2 = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs)
+        let input1 = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateSystem: cs)
+        let input2 = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input1, input2)
      }
 
      func testEqual_False() {
-        let input1            = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs)
-        let input2: Geometry  = Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0), precision: precision, coordinateReferenceSystem: crs)
+        let input1            = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 2.0, y: 2.0), (x: 2.0, y: 3.0), (x: 3.5, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateSystem: cs)
+        let input2: Geometry  = Point<Coordinate2D>(coordinate: (x: 1.0, y: 1.0), precision: precision, coordinateSystem: cs)
 
         XCTAssertFalse(input1.equals(input2), "\(input1) is not equal to \(input2)")
      }
@@ -79,10 +79,10 @@ class Polygon_Geometry_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCas
 class Polygon_Geometry_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(Polygon<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(Polygon<Coordinate2DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -91,10 +91,10 @@ class Polygon_Geometry_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCa
 class Polygon_Geometry_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(Polygon<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(Polygon<Coordinate3D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -103,10 +103,10 @@ class Polygon_Geometry_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCas
 class Polygon_Geometry_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(Polygon<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(Polygon<Coordinate3DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -115,10 +115,10 @@ class Polygon_Geometry_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCa
 class Polygon_Geometry_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(Polygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(Polygon<Coordinate2D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -127,10 +127,10 @@ class Polygon_Geometry_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 class Polygon_Geometry_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(Polygon<Coordinate2DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(Polygon<Coordinate2DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -139,10 +139,10 @@ class Polygon_Geometry_Coordinate2DM_FixedPrecision_Cartesian_Tests: XCTestCase 
 class Polygon_Geometry_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(Polygon<Coordinate3D>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(Polygon<Coordinate3D>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }
 
@@ -151,9 +151,9 @@ class Polygon_Geometry_Coordinate3D_FixedPrecision_Cartesian_Tests: XCTestCase {
 class Polygon_Geometry_Coordinate3DM_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testDimension () {
-        XCTAssertEqual(Polygon<Coordinate3DM>(precision: precision, coordinateReferenceSystem: crs).dimension, geometryDimension)
+        XCTAssertEqual(Polygon<Coordinate3DM>(precision: precision, coordinateSystem: cs).dimension, geometryDimension)
     }
 }

--- a/Tests/GeoFeaturesTests/Polygon+SurfaceTests.swift
+++ b/Tests/GeoFeaturesTests/Polygon+SurfaceTests.swift
@@ -30,58 +30,58 @@ import GeoFeatures
 class Polygon_Surface_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100000)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testArea_Empty() {
-        XCTAssertEqual(Polygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs).area(), 0.0)
+        XCTAssertEqual(Polygon<Coordinate2D>(precision: precision, coordinateSystem: cs).area(), 0.0)
     }
 
     func testArea_Triangle() {
-        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 8.29, y: 0.88), (x: 2.96, y: 5.15), (x: 9.33, y: 7.62), (x: 8.29, y: 0.88)], []), precision: precision, coordinateReferenceSystem: crs).area(), 20.1825)
+        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 8.29, y: 0.88), (x: 2.96, y: 5.15), (x: 9.33, y: 7.62), (x: 8.29, y: 0.88)], []), precision: precision, coordinateSystem: cs).area(), 20.1825)
     }
 
     func testArea_RegularQuadrilateral() {
-        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 8.29, y: 0.88), (x: 3.18, y: 3.12), (x: 5.43, y: 8.22), (x: 10.53, y: 5.98), (x: 8.29, y: 0.88)], []), precision: precision, coordinateReferenceSystem: crs).area(), 31.0643)
+        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 8.29, y: 0.88), (x: 3.18, y: 3.12), (x: 5.43, y: 8.22), (x: 10.53, y: 5.98), (x: 8.29, y: 0.88)], []), precision: precision, coordinateSystem: cs).area(), 31.0643)
     }
 
     func testArea_SimplePolygon1() {
-        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 0.72, y: 2.28), (x: 2.66, y: 4.71), (x: 5.0, y: 3.5), (x: 3.63, y: 2.52), (x: 4.0, y: 1.6), (x: 1.9, y: 1.0), (x: 0.72, y: 2.28)], []), precision: precision, coordinateReferenceSystem: crs).area(), 8.3593)
+        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 0.72, y: 2.28), (x: 2.66, y: 4.71), (x: 5.0, y: 3.5), (x: 3.63, y: 2.52), (x: 4.0, y: 1.6), (x: 1.9, y: 1.0), (x: 0.72, y: 2.28)], []), precision: precision, coordinateSystem: cs).area(), 8.3593)
     }
 
     func testArea_SimplePolygon2() {
-        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 0, y: 0), (x: 0, y: 7), (x: 4, y: 2), (x: 2, y: 0), (x: 0, y: 0)], []), precision: precision, coordinateReferenceSystem: crs).area(), 16.0)
+        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 0, y: 0), (x: 0, y: 7), (x: 4, y: 2), (x: 2, y: 0), (x: 0, y: 0)], []), precision: precision, coordinateSystem: cs).area(), 16.0)
     }
 
     func testArea_SimplePolygon3() {
-        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 0, y: 0), (x: 0, y: 6), (x: 6, y: 6), (x: 6, y: 0), (x: 0, y: 0)], []), precision: precision, coordinateReferenceSystem: crs).area(), 36.0)
+        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 0, y: 0), (x: 0, y: 6), (x: 6, y: 6), (x: 6, y: 0), (x: 0, y: 0)], []), precision: precision, coordinateSystem: cs).area(), 36.0)
     }
 
     func testArea_SimplePolygon_WithHole() {
-        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 0, y: 0), (x: 0, y: 6), (x: 6, y: 6), (x: 6, y: 0), (x: 0, y: 0)], [[(x: 1, y: 1), (x: 4, y: 1), (x: 4, y: 2), (x: 1, y: 2), (x: 1, y: 1)]]), precision: precision, coordinateReferenceSystem: crs).area(), 33.0)
+        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 0, y: 0), (x: 0, y: 6), (x: 6, y: 6), (x: 6, y: 0), (x: 0, y: 0)], [[(x: 1, y: 1), (x: 4, y: 1), (x: 4, y: 2), (x: 1, y: 2), (x: 1, y: 1)]]), precision: precision, coordinateSystem: cs).area(), 33.0)
     }
 
     func testArea_Pentagon() {
-        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 8.29, y: 0.88), (x: 7.61, y: 4.86), (x: 1.53, y: 3.60), (x: 7.86, y: 8.36), (x: 10.79, y: 4.77), (x: 8.29, y: 0.88)], []), precision: precision, coordinateReferenceSystem: crs).area(), 22.35635)
+        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 8.29, y: 0.88), (x: 7.61, y: 4.86), (x: 1.53, y: 3.60), (x: 7.86, y: 8.36), (x: 10.79, y: 4.77), (x: 8.29, y: 0.88)], []), precision: precision, coordinateSystem: cs).area(), 22.35635)
     }
 
     func testArea_RegularPentagon() {
-        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 8.29, y: 0.88), (x: 3.81, y: 2.06), (x: 3.54, y: 6.68), (x: 7.86, y: 8.36), (x: 10.79, y: 4.77), (x: 8.29, y: 0.88)], []), precision: precision, coordinateReferenceSystem: crs).area(), 36.89385)
+        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 8.29, y: 0.88), (x: 3.81, y: 2.06), (x: 3.54, y: 6.68), (x: 7.86, y: 8.36), (x: 10.79, y: 4.77), (x: 8.29, y: 0.88)], []), precision: precision, coordinateSystem: cs).area(), 36.89385)
     }
 
     func testArea_RegularDecagon() {
-        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 8.29, y: 0.88), (x: 5.85, y: 0.74), (x: 3.81, y: 2.06), (x: 2.92, y: 4.33), (x: 3.54, y: 6.68), (x: 5.43, y: 8.22), (x: 7.86, y: 8.36), (x: 9.91, y: 7.04), (x: 10.79, y: 4.77), (x: 10.17, y: 2.42), (x: 8.29, y: 0.88)], []), precision: precision, coordinateReferenceSystem: crs).area(), 45.61285)
+        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 8.29, y: 0.88), (x: 5.85, y: 0.74), (x: 3.81, y: 2.06), (x: 2.92, y: 4.33), (x: 3.54, y: 6.68), (x: 5.43, y: 8.22), (x: 7.86, y: 8.36), (x: 9.91, y: 7.04), (x: 10.79, y: 4.77), (x: 10.17, y: 2.42), (x: 8.29, y: 0.88)], []), precision: precision, coordinateSystem: cs).area(), 45.61285)
     }
 
     func testArea_Tetrakaidecagon() {
-        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 8.32, y: 1.66), (x: 6.55, y: 0.62), (x: 4.88, y: 1.14), (x: 8.32, y: 2.95), (x: 2.96, y: 3.98), (x: 7.04, y: 6.15), (x: 7.24, y: 7.20), (x: 5.43, y: 8.22), (x: 7.17, y: 8.48), (x: 8.84, y: 7.96), (x: 6.65, y: 4.32), (x: 10.76, y: 5.12), (x: 8.87, y: 4.06), (x: 9.74, y: 1.86), (x: 8.32, y: 1.66)], []), precision: precision, coordinateReferenceSystem: crs).area(), 18.63)
+        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 8.32, y: 1.66), (x: 6.55, y: 0.62), (x: 4.88, y: 1.14), (x: 8.32, y: 2.95), (x: 2.96, y: 3.98), (x: 7.04, y: 6.15), (x: 7.24, y: 7.20), (x: 5.43, y: 8.22), (x: 7.17, y: 8.48), (x: 8.84, y: 7.96), (x: 6.65, y: 4.32), (x: 10.76, y: 5.12), (x: 8.87, y: 4.06), (x: 9.74, y: 1.86), (x: 8.32, y: 1.66)], []), precision: precision, coordinateSystem: cs).area(), 18.63)
     }
 
     func testArea_RegularQuadrilateral_CrossingOrigin () {
-        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 1.00, y: -1.00), (x: -1.00, y: -1.00), (x: -1.00, y: 1.00), (x: 1.00, y: 1.00), (x: 1.00, y: -1.00)], []), precision: precision, coordinateReferenceSystem: crs).area(), 4.0)
+        XCTAssertEqual(Polygon<Coordinate2D>(rings: ([(x: 1.00, y: -1.00), (x: -1.00, y: -1.00), (x: -1.00, y: 1.00), (x: 1.00, y: 1.00), (x: 1.00, y: -1.00)], []), precision: precision, coordinateSystem: cs).area(), 4.0)
     }
 
     func testPerformanceArea_Quadrilateral() {
-        let geometry = Polygon<Coordinate2D>(rings: ([(x: 8.29, y: 0.88), (x: 3.18, y: 3.12), (x: 5.43, y: 8.22), (x: 10.53, y: 5.98), (x: 8.29, y: 0.88)], []), precision: precision, coordinateReferenceSystem: crs)
+        let geometry = Polygon<Coordinate2D>(rings: ([(x: 8.29, y: 0.88), (x: 3.18, y: 3.12), (x: 5.43, y: 8.22), (x: 10.53, y: 5.98), (x: 8.29, y: 0.88)], []), precision: precision, coordinateSystem: cs)
 
         self.measure {
 

--- a/Tests/GeoFeaturesTests/PolygonTests.swift
+++ b/Tests/GeoFeaturesTests/PolygonTests.swift
@@ -30,7 +30,7 @@ import XCTest
 class Polygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FloatingPrecision()
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testInit_NoArg() {
 
@@ -42,16 +42,16 @@ class Polygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
     func testInit_NoArg_Defaults() {
         let input    = Polygon<Coordinate2D>()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? FloatingPrecision, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = Polygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input = Polygon<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? FloatingPrecision, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Precision() {
@@ -62,16 +62,16 @@ class Polygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
     }
 
     func testInit_CRS() {
-        let input = Polygon<Coordinate2D>(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = Polygon<Coordinate2D>(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, expected)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, expected)
     }
 
     func testInit_RIngs() {
 
-        let input    = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs)
+        let input    = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateSystem: cs)
+        let expected = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.outerRing.count, 5)
         XCTAssertEqual(input.innerRings.count, 1)
@@ -80,8 +80,8 @@ class Polygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Tuple() {
 
-        let input    = Polygon<Coordinate2D>(outerRing: [(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], innerRings: [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]], precision: precision, coordinateReferenceSystem: crs)
-        let expected = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs)
+        let input    = Polygon<Coordinate2D>(outerRing: [(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], innerRings: [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]], precision: precision, coordinateSystem: cs)
+        let expected = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
      }
@@ -90,7 +90,7 @@ class Polygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input    = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs)
+        let input    = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateSystem: cs)
         let expected = "Polygon<Coordinate2D>([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]])"
 
         XCTAssertEqual(input.description, expected)
@@ -98,7 +98,7 @@ class Polygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input    = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs)
+        let input    = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateSystem: cs)
         let expected = "Polygon<Coordinate2D>([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]])"
 
         XCTAssertEqual(input.debugDescription, expected)
@@ -106,22 +106,22 @@ class Polygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription_Empty() {
 
-        let input    = Polygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input    = Polygon<Coordinate2D>(precision: precision, coordinateSystem: cs)
         let expected = "Polygon<Coordinate2D>([], [])"
 
         XCTAssertEqual(input.description, expected)
     }
 
     func testOperatorEqual_Geometry_Polygon() {
-        let input: Geometry                 = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs)
-        let expected: Polygon<Coordinate2D> = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs)
+        let input: Geometry                 = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateSystem: cs)
+        let expected: Polygon<Coordinate2D> = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(input == expected)
     }
 
     func testOperatorEqual_Polygon_Geometry() {
-        let input: Polygon<Coordinate2D> = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs)
-        let expected: Geometry           = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs)
+        let input: Polygon<Coordinate2D> = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateSystem: cs)
+        let expected: Geometry           = Polygon<Coordinate2D>(rings: ([(x: 6.0, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.0, y: 3.0)], [[(x: 5.0, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.0, y: 3.0)]]), precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(input == expected)
     }
@@ -132,7 +132,7 @@ class Polygon_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class Polygon_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     let precision = FixedPrecision(scale: 100)
-    let crs       = Cartesian()
+    let cs       = Cartesian()
 
     func testInit_NoArg() {
 
@@ -144,16 +144,16 @@ class Polygon_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
     func testInit_NoArg_Defaults() {
         let input    = Polygon<Coordinate2D>()
 
-        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateReferenceSystem
+        // FIXME: Currently Precision and CoordinateRefereceSystem can not be Equitable and be used for anything otherthan Generic constraints because it's a protocol, this limits testing of the defaultPrecision and defaultCoordinateSystem
         // XCTAssertEqual(input.precision as? FloatingPrecision, GeoFeatures.defaultPrecision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, GeoFeatures.defaultCoordinateReferenceSystem)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, GeoFeatures.defaultCoordinateSystem)
     }
 
     func testInit_Precision_CRS() {
-        let input = Polygon<Coordinate2D>(precision: precision, coordinateReferenceSystem: crs)
+        let input = Polygon<Coordinate2D>(precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.precision as? FixedPrecision, precision)
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, crs)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, cs)
     }
 
     func testInit_Precision() {
@@ -164,16 +164,16 @@ class Polygon_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
     }
 
     func testInit_CRS() {
-        let input = Polygon<Coordinate2D>(coordinateReferenceSystem: crs)
-        let expected = crs
+        let input = Polygon<Coordinate2D>(coordinateSystem: cs)
+        let expected = cs
 
-        XCTAssertEqual(input.coordinateReferenceSystem as? Cartesian, expected)
+        XCTAssertEqual(input.coordinateSystem as? Cartesian, expected)
     }
 
     func testInit_RIngs() {
 
-        let input    = Polygon<Coordinate2D>(rings: ([(x: 6.006, y: 1.001), (x: 1.001, y: 1.001), (x: 1.001, y: 3.003), (x: 3.501, y: 4.001), (x: 6.006, y: 3.003)], [[(x: 5.005, y: 2.002), (x: 3.003, y: 1.501), (x: 3.003, y: 3.003), (x: 4.004, y: 3.503), (x: 5.005, y: 3.003)]]), precision: precision, coordinateReferenceSystem: crs)
-        let expected = Polygon<Coordinate2D>(rings: ([(x: 6.01, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.01, y: 3.0)], [[(x: 5.01, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.01, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs)
+        let input    = Polygon<Coordinate2D>(rings: ([(x: 6.006, y: 1.001), (x: 1.001, y: 1.001), (x: 1.001, y: 3.003), (x: 3.501, y: 4.001), (x: 6.006, y: 3.003)], [[(x: 5.005, y: 2.002), (x: 3.003, y: 1.501), (x: 3.003, y: 3.003), (x: 4.004, y: 3.503), (x: 5.005, y: 3.003)]]), precision: precision, coordinateSystem: cs)
+        let expected = Polygon<Coordinate2D>(rings: ([(x: 6.01, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.01, y: 3.0)], [[(x: 5.01, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.01, y: 3.0)]]), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input.outerRing.count, 5)
         XCTAssertEqual(input.innerRings.count, 1)
@@ -182,8 +182,8 @@ class Polygon_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testInit_Tuple() {
 
-        let input    = Polygon<Coordinate2D>(outerRing: [(x: 6.006, y: 1.001), (x: 1.001, y: 1.001), (x: 1.001, y: 3.003), (x: 3.501, y: 4.001), (x: 6.006, y: 3.003)], innerRings: [[(x: 5.005, y: 2.002), (x: 3.003, y: 1.501), (x: 3.003, y: 3.003), (x: 4.004, y: 3.503), (x: 5.005, y: 3.003)]], precision: precision, coordinateReferenceSystem: crs)
-        let expected = Polygon<Coordinate2D>(rings: ([(x: 6.01, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.01, y: 3.0)], [[(x: 5.01, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.01, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs)
+        let input    = Polygon<Coordinate2D>(outerRing: [(x: 6.006, y: 1.001), (x: 1.001, y: 1.001), (x: 1.001, y: 3.003), (x: 3.501, y: 4.001), (x: 6.006, y: 3.003)], innerRings: [[(x: 5.005, y: 2.002), (x: 3.003, y: 1.501), (x: 3.003, y: 3.003), (x: 4.004, y: 3.503), (x: 5.005, y: 3.003)]], precision: precision, coordinateSystem: cs)
+        let expected = Polygon<Coordinate2D>(rings: ([(x: 6.01, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.01, y: 3.0)], [[(x: 5.01, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.01, y: 3.0)]]), precision: precision, coordinateSystem: cs)
 
         XCTAssertEqual(input, expected)
      }
@@ -192,7 +192,7 @@ class Polygon_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDescription() {
 
-        let input    = Polygon<Coordinate2D>(rings: ([(x: 6.006, y: 1.001), (x: 1.001, y: 1.001), (x: 1.001, y: 3.003), (x: 3.501, y: 4.001), (x: 6.006, y: 3.003)], [[(x: 5.005, y: 2.002), (x: 3.003, y: 1.501), (x: 3.003, y: 3.003), (x: 4.004, y: 3.503), (x: 5.005, y: 3.003)]]), precision: precision, coordinateReferenceSystem: crs)
+        let input    = Polygon<Coordinate2D>(rings: ([(x: 6.006, y: 1.001), (x: 1.001, y: 1.001), (x: 1.001, y: 3.003), (x: 3.501, y: 4.001), (x: 6.006, y: 3.003)], [[(x: 5.005, y: 2.002), (x: 3.003, y: 1.501), (x: 3.003, y: 3.003), (x: 4.004, y: 3.503), (x: 5.005, y: 3.003)]]), precision: precision, coordinateSystem: cs)
         let expected = "Polygon<Coordinate2D>([(x: 6.01, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.01, y: 3.0)], [[(x: 5.01, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.01, y: 3.0)]])"
 
         XCTAssertEqual(input.description, expected)
@@ -200,22 +200,22 @@ class Polygon_Coordinate2D_FixedPrecision_Cartesian_Tests: XCTestCase {
 
     func testDebugDescription() {
 
-        let input    = Polygon<Coordinate2D>(rings: ([(x: 6.006, y: 1.001), (x: 1.001, y: 1.001), (x: 1.001, y: 3.003), (x: 3.501, y: 4.001), (x: 6.006, y: 3.003)], [[(x: 5.005, y: 2.002), (x: 3.003, y: 1.501), (x: 3.003, y: 3.003), (x: 4.004, y: 3.503), (x: 5.005, y: 3.003)]]), precision: precision, coordinateReferenceSystem: crs)
+        let input    = Polygon<Coordinate2D>(rings: ([(x: 6.006, y: 1.001), (x: 1.001, y: 1.001), (x: 1.001, y: 3.003), (x: 3.501, y: 4.001), (x: 6.006, y: 3.003)], [[(x: 5.005, y: 2.002), (x: 3.003, y: 1.501), (x: 3.003, y: 3.003), (x: 4.004, y: 3.503), (x: 5.005, y: 3.003)]]), precision: precision, coordinateSystem: cs)
         let expected = "Polygon<Coordinate2D>([(x: 6.01, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.01, y: 3.0)], [[(x: 5.01, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.01, y: 3.0)]])"
 
         XCTAssertEqual(input.debugDescription, expected)
     }
 
     func testOperatorEqual_Geometry_Polygon() {
-        let input: Geometry                 = Polygon<Coordinate2D>(rings: ([(x: 6.006, y: 1.001), (x: 1.001, y: 1.001), (x: 1.001, y: 3.003), (x: 3.501, y: 4.001), (x: 6.006, y: 3.003)], [[(x: 5.005, y: 2.002), (x: 3.003, y: 1.501), (x: 3.003, y: 3.003), (x: 4.004, y: 3.503), (x: 5.005, y: 3.003)]]), precision: precision, coordinateReferenceSystem: crs)
-        let expected: Polygon<Coordinate2D> = Polygon<Coordinate2D>(rings: ([(x: 6.01, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.01, y: 3.0)], [[(x: 5.01, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.01, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs)
+        let input: Geometry                 = Polygon<Coordinate2D>(rings: ([(x: 6.006, y: 1.001), (x: 1.001, y: 1.001), (x: 1.001, y: 3.003), (x: 3.501, y: 4.001), (x: 6.006, y: 3.003)], [[(x: 5.005, y: 2.002), (x: 3.003, y: 1.501), (x: 3.003, y: 3.003), (x: 4.004, y: 3.503), (x: 5.005, y: 3.003)]]), precision: precision, coordinateSystem: cs)
+        let expected: Polygon<Coordinate2D> = Polygon<Coordinate2D>(rings: ([(x: 6.01, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.01, y: 3.0)], [[(x: 5.01, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.01, y: 3.0)]]), precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(input == expected)
     }
 
     func testOperatorEqual_Polygon_Geometry() {
-        let input: Polygon<Coordinate2D> = Polygon<Coordinate2D>(rings: ([(x: 6.006, y: 1.001), (x: 1.001, y: 1.001), (x: 1.001, y: 3.003), (x: 3.501, y: 4.001), (x: 6.006, y: 3.003)], [[(x: 5.005, y: 2.002), (x: 3.003, y: 1.501), (x: 3.003, y: 3.003), (x: 4.004, y: 3.503), (x: 5.005, y: 3.003)]]), precision: precision, coordinateReferenceSystem: crs)
-        let expected: Geometry           = Polygon<Coordinate2D>(rings: ([(x: 6.01, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.01, y: 3.0)], [[(x: 5.01, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.01, y: 3.0)]]), precision: precision, coordinateReferenceSystem: crs)
+        let input: Polygon<Coordinate2D> = Polygon<Coordinate2D>(rings: ([(x: 6.006, y: 1.001), (x: 1.001, y: 1.001), (x: 1.001, y: 3.003), (x: 3.501, y: 4.001), (x: 6.006, y: 3.003)], [[(x: 5.005, y: 2.002), (x: 3.003, y: 1.501), (x: 3.003, y: 3.003), (x: 4.004, y: 3.503), (x: 5.005, y: 3.003)]]), precision: precision, coordinateSystem: cs)
+        let expected: Geometry           = Polygon<Coordinate2D>(rings: ([(x: 6.01, y: 1.0), (x: 1.0, y: 1.0), (x: 1.0, y: 3.0), (x: 3.5, y: 4.0), (x: 6.01, y: 3.0)], [[(x: 5.01, y: 2.0), (x: 3.0, y: 1.5), (x: 3.0, y: 3.0), (x: 4.0, y: 3.5), (x: 5.01, y: 3.0)]]), precision: precision, coordinateSystem: cs)
 
         XCTAssertTrue(input == expected)
     }

--- a/Tests/GeoFeaturesTests/WKTReaderTests.swift
+++ b/Tests/GeoFeaturesTests/WKTReaderTests.swift
@@ -31,7 +31,7 @@ import GeoFeatures
 class WKTReader_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     private typealias WKTReaderType = WKTReader<Coordinate2D>
-    private var wktReader = WKTReaderType(precision: FloatingPrecision(), coordinateReferenceSystem: Cartesian())
+    private var wktReader = WKTReaderType(precision: FloatingPrecision(), coordinateSystem: Cartesian())
 
     // MARK: - Init
 
@@ -812,7 +812,7 @@ class WKTReader_Coordinate2D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class WKTReader_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     private typealias WKTReaderType = WKTReader<Coordinate2DM>
-    private var wktReader = WKTReaderType(precision: FloatingPrecision(), coordinateReferenceSystem: Cartesian())
+    private var wktReader = WKTReaderType(precision: FloatingPrecision(), coordinateSystem: Cartesian())
 
     // MARK: Point
 
@@ -929,7 +929,7 @@ class WKTReader_Coordinate2DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class WKTReader_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     private typealias WKTReaderType = WKTReader<Coordinate3D>
-    private var wktReader = WKTReaderType(precision: FloatingPrecision(), coordinateReferenceSystem: Cartesian())
+    private var wktReader = WKTReaderType(precision: FloatingPrecision(), coordinateSystem: Cartesian())
 
     // MARK: Point
 
@@ -1031,7 +1031,7 @@ class WKTReader_Coordinate3D_FloatingPrecision_Cartesian_Tests: XCTestCase {
 class WKTReader_Coordinate3DM_FloatingPrecision_Cartesian_Tests: XCTestCase {
 
     private typealias WKTReaderType = WKTReader<Coordinate3DM>
-    private var wktReader = WKTReaderType(precision: FloatingPrecision(), coordinateReferenceSystem: Cartesian())
+    private var wktReader = WKTReaderType(precision: FloatingPrecision(), coordinateSystem: Cartesian())
 
     // MARK: Point
 

--- a/Tests/GeoFeaturesTests/WKTWriterTests.swift
+++ b/Tests/GeoFeaturesTests/WKTWriterTests.swift
@@ -30,7 +30,7 @@ fileprivate struct UnsupportedGeometry: Geometry {
 
     let precision: Precision = FloatingPrecision()
 
-    let coordinateReferenceSystem: CoordinateReferenceSystem = Cartesian()
+    let coordinateSystem: CoordinateSystem = Cartesian()
 
     let dimension: GeoFeatures.Dimension = .one
 


### PR DESCRIPTION
Changing CoordinateReferenceSystem to CoordinateSystem so as not to confuse it with spatial reference systems which are also know as coordinate reference systems in OGC and others.