### PR TITLE
Correcting warnings for unused parameters 

### DIFF
--- a/Sources/GeoFeatures/GeometryCollection.swift
+++ b/Sources/GeoFeatures/GeometryCollection.swift
@@ -205,7 +205,7 @@ extension GeometryCollection: Collection {
 
         if keepCapacity {
 
-            buffer.withUnsafeMutablePointers { (header, elements) -> Void in
+            buffer.withUnsafeMutablePointerToHeader { (header) -> Void in
                 header.pointee.count = 0
             }
         } else {

--- a/Sources/GeoFeatures/LineString.swift
+++ b/Sources/GeoFeatures/LineString.swift
@@ -227,7 +227,7 @@ extension LineString: Collection {
 
         if keepCapacity {
 
-            buffer.withUnsafeMutablePointers { (header, elements) -> Void in
+            buffer.withUnsafeMutablePointerToHeader { (header) -> Void in
                 header.pointee.count = 0
             }
         } else {

--- a/Sources/GeoFeatures/LinearRing.swift
+++ b/Sources/GeoFeatures/LinearRing.swift
@@ -227,7 +227,7 @@ extension LinearRing: Collection {
 
         if keepCapacity {
 
-            buffer.withUnsafeMutablePointers { (header, elements) -> Void in
+            buffer.withUnsafeMutablePointerToHeader { (header) -> Void in
                 header.pointee.count = 0
             }
         } else {

--- a/Sources/GeoFeatures/MultiLineString.swift
+++ b/Sources/GeoFeatures/MultiLineString.swift
@@ -207,7 +207,7 @@ extension MultiLineString: Collection {
 
         if keepCapacity {
 
-            buffer.withUnsafeMutablePointers { (header, elements) -> Void in
+            buffer.withUnsafeMutablePointerToHeader { (header) -> Void in
                 header.pointee.count = 0
             }
         } else {

--- a/Sources/GeoFeatures/MultiPoint.swift
+++ b/Sources/GeoFeatures/MultiPoint.swift
@@ -207,7 +207,7 @@ extension MultiPoint: Collection {
 
         if keepCapacity {
 
-            buffer.withUnsafeMutablePointers { (header, elements) -> Void in
+            buffer.withUnsafeMutablePointerToHeader { (header) -> Void in
                 header.pointee.count = 0
             }
         } else {

--- a/Sources/GeoFeatures/MultiPolygon.swift
+++ b/Sources/GeoFeatures/MultiPolygon.swift
@@ -207,7 +207,7 @@ extension MultiPolygon: Collection {
 
         if keepCapacity {
 
-            buffer.withUnsafeMutablePointers { (header, elements) -> Void in
+            buffer.withUnsafeMutablePointerToHeader { (header) -> Void in
                 header.pointee.count = 0
             }
         } else {


### PR DESCRIPTION
Correcting warnings for unused parameters by switching to `withUnsafeMutablePointerToHeader` instead of `withUnsafeMutablePointers`