### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,7 @@ Minimum Runtime Version
 >
 > To build and run on **Linux** we have a a preconfigure **Vagrant** file located at [https://github.com/tonystone/vagrant-swift](https://github.com/tonystone/vagrant-swift)
 >
-> Use:
-> ```
-> > vagrant --swift-version=2017-08-03 up
-> ```
+> See the [README](https://github.com/tonystone/vagrant-swift/blob/master/README.md) for instructions.
 > 
 
 ## License


### PR DESCRIPTION
- Removing specific instructions for using vargrant-swift and replacing with a reference to the README.md (this will avoid constent updates to this project when updating the functionality of vagrant-swift).